### PR TITLE
added revision dates and related instructions

### DIFF
--- a/APE1.rst
+++ b/APE1.rst
@@ -3,7 +3,9 @@ APE Purpose and Process
 
 author: Perry Greenfield
 
-date: 2013 October 11
+date-created: 2013 October 11
+
+date-last-revised: 2013 November 8
 
 type: Process
 

--- a/APE2.rst
+++ b/APE2.rst
@@ -3,7 +3,9 @@ Astropy Release Cycle and Version Numbering
 
 author: Erik Tollerud
 
-date: Nov 18, 2013
+date-created: 2013 November 18
+
+date-last-revised: 2013 December 11
 
 type: Process
 

--- a/APEtemplate.rst
+++ b/APEtemplate.rst
@@ -3,7 +3,9 @@
 
 author: <your name>
 
-date: <date the APE was submitted>
+date-created: 2013 November 5 <replace with the date you submit the APE>
+
+date-last-revised: 2013 December 17 <keep this up to date anytime something changes>
 
 type: <one of these three: Standard Track, Informational, Process>
 


### PR DESCRIPTION
As per the astropy-dev discussion, this adds a "date-last-revised" field, and changes the existing date field to "date-created".  It does this for the existing APEs and the template.
