### PR TITLE
APE6 - Enhanced Character Separated Values table format

### DIFF
--- a/APE6.rst
+++ b/APE6.rst
@@ -1,4 +1,4 @@
-Enhanced Character-Separated-Values format
+Enhanced Character Separated Values format
 ------------------------------------------
 
 author: Tom Aldcroft
@@ -19,7 +19,7 @@ APE6 is primarily a specification of a new standard for the interchange of
 tabular data in a text-only format.  The proposed format handles the key issue
 of serializing column specifications and table metadata by using a YAML-encoded
 data structure.  The actual tabular data are stored in a standard
-character-separated-values (CSV) format, giving compatibility with a wide variety of
+character separated values (CSV) format, giving compatibility with a wide variety of
 non-specialized CSV table readers.
 
 Using YAML makes it extremely easy for applications *and humans* to read both
@@ -323,7 +323,7 @@ Other implementations must likewise use an ordered mapping when reading and the
 In addition, the reference Python implementation outputs the column attributes
 in the order ``'name'``, ``'unit'``, ``'type'``, ``'format'``,
 ``'description'``, and ``'meta'``.  This is not a ECSV requirement but is
-recommended for humans accessibility.
+recommended for human accessibility.
 
 Header details
 ^^^^^^^^^^^^^^^^
@@ -428,7 +428,7 @@ the following rules:
   characters.
 
 Multidimensional columns
-^^^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""""
 
 Multidimensional columns are not supported in version 1.0 of the ECSV format.
 

--- a/APE6.rst
+++ b/APE6.rst
@@ -11,6 +11,8 @@ type: Standard Track
 
 status: Discussion
 
+version: 0.9
+
 
 Abstract
 --------
@@ -212,7 +214,7 @@ overall structure:
 - A CSV-formatted data section in which the first line contains the column names
   and subsequent lines contains the data values.
 
-Version 1.0 of the ECSV format specification and the reference Python
+Version 0.9 of the ECSV format specification and the reference Python
 implementation assumes ASCII-encoded header and data sections.  Support
 for unicode (in particular UTF-8) may be added in subsequent versions.
 
@@ -270,7 +272,7 @@ Now we write this to a file using the ECSV format and print it::
 
   >>> t.write('example.ecsv', format='ascii.ecsv')
   >>> cat example.ecsv
-  # %ECSV 1.0
+  # %ECSV 0.9
   # ---
   # datatype:
   # - {name: a, unit: m / s, datatype: int64, format: '%03d'}
@@ -311,7 +313,7 @@ Now we write the table to standard out::
 
   >>> import sys
   >>> t.write(sys.stdout, format='ascii.ecsv')
-  # %ECSV 1.0
+  # %ECSV 0.9
   # ---
   # datatype:
   # - {name: a, unit: m / s, type: int64, format: '%5.2f', description: Column A}
@@ -446,7 +448,7 @@ the following rules:
 Multidimensional columns
 """"""""""""""""""""""""
 
-Multidimensional columns are not supported in version 1.0 of the ECSV format.
+Multidimensional columns are not supported in version 0.9 of the ECSV format.
 
 None of the available text data formats supports multidimensional columns
 with more than one element per row.  Although in many cases

--- a/APE6.rst
+++ b/APE6.rst
@@ -1,5 +1,5 @@
-Enhanced Character Separated Values format
-------------------------------------------
+Enhanced Character Separated Values table format
+------------------------------------------------
 
 author: Tom Aldcroft
 
@@ -15,8 +15,14 @@ status: Discussion
 Abstract
 --------
 
-APE6 is primarily a specification of a new standard for the interchange of
-tabular data in a text-only format.  The proposed format handles the key issue
+Data tables in astronomical analysis frequently contain additional metadata
+beyond just the column names and data values.  Common attributes include the
+numerical data type, the physical unit, and a longer textual description of the
+column content.  These attributes can be reprented in binary formats such as
+FITS, but the available options for a text-only format are inadequate.
+
+APE6 proposes to fill this void by specification of a standard for the interchange of
+tabular data in a text-only format.  The format handles the key issue
 of serializing column specifications and table metadata by using a YAML-encoded
 data structure.  The actual tabular data are stored in a standard
 character separated values (CSV) format, giving compatibility with a wide variety of
@@ -27,9 +33,14 @@ the standardized data format elements (e.g. column name, type, description) as
 well as complex metadata structures.  YAML also lends itself to simple table
 modifications by humans in a plain text editor.
 
-The reference Python implementation in ``astropy.io.ascii`` is relatively straightforward and
-will provide a significant benefit of allowing text serialization of most astropy
-Table objects, persistent storage, and subsequent interchange with other users.
+The reference Python implementation in ``astropy.io.ascii`` is relatively
+straightforward and will provide a significant benefit of allowing text
+serialization of most astropy Table objects, persistent storage, and subsequent
+interchange with other users.
+
+Although developed in the context of Astropy, there is nothing
+astronomy-specific in this format and it could be useful for other domains or
+languages.  However, promoting that is beyond the scope of this APE.
 
 Existing standards
 --------------------
@@ -180,10 +191,12 @@ the `JSON Table Schema
 <http://dataprotocols.org/json-table-schema/>`_.
 
 
-After evaluation and discussion with that community, we find that the Tabular
-Data Package and associated standards would require a fair degree of
-modification to fully suit our needs.  More crucially, the decision to rely on
-YAML instead of JSON for serialization precludes direct use of the TDP.
+After evaluation and a brief ``discussion with that community
+<https://lists.okfn.org/pipermail/data-protocols/2014-April/000093.html>`_, we
+find that the Tabular Data Package and associated standards would require a
+fair degree of modification to fully suit our needs.  More crucially, the
+decision to rely on YAML instead of JSON for serialization precludes direct use
+of the TDP.
 
 
 Detailed description
@@ -467,7 +480,7 @@ Further work is pending discussion of APE6.
 Backward compatibility
 ----------------------
 
-This section describes the ways in which the APE breaks backward compatibility.
+This is a new feature and there are no issues with backward compatibility.
 
 
 Alternatives

--- a/APE6.rst
+++ b/APE6.rst
@@ -5,7 +5,7 @@ author: Tom Aldcroft
 
 date-created: 2014 April 12
 
-date-last-revised: 2014 December 28
+date-last-revised: 2015 January 20
 
 type: Standard Track
 
@@ -233,7 +233,7 @@ used programming languages (with the notable exception of IDL).
 
 Translating to / from the data structure provided by a ECSV header into the native
 structure that an application uses should generally be quite easy because the
-functional elements (e.g. column name, type) are ubiquitous.  Generally
+functional elements (e.g. column name, data type) are ubiquitous.  Generally
 speaking manipulating data structures programmatically is easier than parsing
 textual data structure fields.
 
@@ -272,9 +272,9 @@ Now we write this to a file using the ECSV format and print it::
   >>> cat example.ecsv
   # %ECSV 1.0
   # ---
-  # columns:
-  # - {name: a, unit: m / s, type: int64, format: '%03d'}
-  # - {name: b, unit: km, type: int64, description: This is column b}
+  # datatype:
+  # - {name: a, unit: m / s, datatype: int64, format: '%03d'}
+  # - {name: b, unit: km, datatype: int64, description: This is column b}
   a b
   001 2
   004 3
@@ -313,10 +313,10 @@ Now we write the table to standard out::
   >>> t.write(sys.stdout, format='ascii.ecsv')
   # %ECSV 1.0
   # ---
-  # columns:
+  # datatype:
   # - {name: a, unit: m / s, type: int64, format: '%5.2f', description: Column A}
   # - name: b
-  #   type: int64
+  #   datatype: int64
   #   meta:
   #     column_meta: {a: 1, b: 2}
   # meta: !!omap
@@ -336,7 +336,7 @@ Other implementations must likewise use an ordered mapping when reading and the
 ``!!omap`` tag when writing for ordered mappings in the data structure.
 
 In addition, the reference Python implementation outputs the column attributes
-in the order ``'name'``, ``'unit'``, ``'type'``, ``'format'``,
+in the order ``'name'``, ``'unit'``, ``'datatype'``, ``'format'``,
 ``'description'``, and ``'meta'``.  This is not a ECSV requirement but is
 recommended for human accessibility.
 
@@ -367,8 +367,8 @@ encouraged.
 
 Standard keywords are:
 
-``columns``: list, required
-   List of column specifiers.
+``datatype``: list, required
+   Top-level data type specification as a list of column specifiers.
 
 ``delimiter``: one-character string, optional, default=``space``
    Delimiter character used to separate the data fields.  Allowed
@@ -392,7 +392,7 @@ Each column specifier is a dictionary structure with the following keys:
 ``name``: string, required
    Column name
 
-``type``: string, required
+``datatype``: string, required
   Column data type.  Allowed types are: ``bool``, ``int8``,
   ``int16``, ``int32``, ``int64``, ``uint8``, ``uint16``, ``uint32``,
   ``uint64``, ``float16``, ``float32``, ``float64``, ``float128``,

--- a/APE6.rst
+++ b/APE6.rst
@@ -15,7 +15,7 @@ status: Discussion
 Abstract
 --------
 
-This APE is primarily a specification of a new standard for the interchange of
+APE6 is primarily a specification of a new standard for the interchange of
 tabular data in a text-only format.  The proposed format handles the key issue
 of serializing column specifications and table metadata by using a JSON-encoded
 data structure which is included in the file as a series of ``#``-prefixed
@@ -359,14 +359,16 @@ the results then takes more effort.
 Branches and pull requests
 --------------------------
 
-PR# XXXX
+PR# 2319: "Implement support for the DTIF format proposed in APE6"
+
+PR# 683: Initial version "Support table metadata in io.ascii"
 
 
 Implementation
 --------------
 
-Much of the implementation is done in PR# XXXX.  Further work is pending
-discussion of APE6.
+Much of the implementation is done in PR# 2319, which was based on PR# 683.
+Further work is pending discussion of APE6.
 
 
 Backward compatibility

--- a/APE6.rst
+++ b/APE6.rst
@@ -481,8 +481,7 @@ Branches and pull requests
 Implementation
 --------------
 
-Much of the implementation is done in PR# 2319, which was based on PR# 683.
-Further work is pending discussion of APE6.
+The implementation is done in PR# 2319, which was based on PR# 683.
 
 
 Backward compatibility

--- a/APE6.rst
+++ b/APE6.rst
@@ -359,9 +359,9 @@ the results then takes more effort.
 Branches and pull requests
 --------------------------
 
-PR# 2319: "Implement support for the DTIF format proposed in APE6"
+`PR# 2319 <https://github.com/astropy/astropy/pull/2319>`_: "Implement support for the DTIF format proposed in APE6"
 
-PR# 683: Initial version "Support table metadata in io.ascii"
+`PR# 683 <https://github.com/astropy/astropy/pull/683>`_: Initial version "Support table metadata in io.ascii"
 
 
 Implementation

--- a/APE6.rst
+++ b/APE6.rst
@@ -191,7 +191,7 @@ the `JSON Table Schema
 <http://dataprotocols.org/json-table-schema/>`_.
 
 
-After evaluation and a brief ``discussion with that community
+After evaluation and a brief `discussion with that community
 <https://lists.okfn.org/pipermail/data-protocols/2014-April/000093.html>`_, we
 find that the Tabular Data Package and associated standards would require a
 fair degree of modification to fully suit our needs.  More crucially, the

--- a/APE6.rst
+++ b/APE6.rst
@@ -5,11 +5,11 @@ author: Tom Aldcroft
 
 date-created: 2014 April 12
 
-date-last-revised: 2015 January 20
+date-last-revised: 2015 January 23
 
 type: Standard Track
 
-status: Discussion
+status: Accepted
 
 version: 0.9
 
@@ -502,4 +502,10 @@ interchange of astropy Tables.
 Decision rationale
 ------------------
 
-<To be filled in when the APE is accepted or rejected>
+This was discussed via pull request #7, with calls for comment sent out to the
+astropy, astropy-dev, and apps@ivoa.net mailing lists.  The general consensus
+was that this is a useful format that will be beneficial to the astronomy
+community.  A number of good suggestions and ideas were incorporated,
+particularly related to compatibility with the ASDF standard.  All comments
+from interested parties were agreeably resolved.  Therefore this APE was
+accepted on January 23rd 2015.

--- a/APE6.rst
+++ b/APE6.rst
@@ -18,8 +18,7 @@ Abstract
 APE6 is primarily a specification of a new standard for the interchange of
 tabular data in a text-only format.  The proposed format handles the key issue
 of serializing column specifications and table metadata by using a JSON-encoded
-data structure which is included in the file as a series of ``#``-prefixed
-comment lines.  The actual tabular data are stored in a standard
+data structure.  The actual tabular data are stored in a standard
 comma-separated-values (CSV) format, giving compatibility with a wide variety of
 non-specialized CSV table readers.  Using JSON makes it extremely easy for
 applications to read both the standardized data format elements (e.g. column
@@ -38,8 +37,10 @@ The well-known `XKCD comic <https://xkcd.com/927/>`_ aptly mocks the
 introduction of new standards.  Let's just stipulate that this standard may be a
 bad idea, but talk about it anyway.  Following the lead of the astronomical data
 community in recently documenting shortcomings of the FITS standard, we start by
-discussing existing widely-used standards and why they are
-lacking.
+discussing existing widely-used standards and why they are lacking.
+
+Note that the existing `Tabular Data Package`_ standard, while not
+used widely in astronomy, may be entirely suitable for our purposes.
 
 CSV
 ^^^^^
@@ -166,8 +167,25 @@ parsing and validation for text serialization.
 Others
 ^^^^^^^^
 
-We are not aware of other widely-used standards for text representation of
-tabular data.
+We are not aware of other widely-used standards in the astronomical
+community for text representation of tabular data.
+
+Tabular Data Package
+^^^^^^^^^^^^^^^^^^^^^
+
+Though not widely used in the astronomical community, since initially drafting
+this APE we have become aware of a very similar standard known as the
+`Tabular Data Package
+<http://dataprotocols.org/tabular-data-package/>`_.  This provides a
+fully-formed protocol for publishing and sharing tabular-style data
+which is conceptually very similar to the proposed DTIF format, with
+the exception of using two files, one pure JSON for the header and one
+pure CSV for the data.  The JSON header follows a schema defined by
+the `JSON Table Schema
+<http://dataprotocols.org/json-table-schema/>`_.
+
+On balance the Tabular Data Package and associated standards seem
+quite suited to our purpose.
 
 
 Detailed description
@@ -180,6 +198,29 @@ overall structure:
   and provide the table definition via a JSON-encoded data structure.
 - A CSV-formatted data section in which the first line contains the column names
   and subsequent lines contains the data values
+
+As mentioned, subsequent to initially drafting this APE we have become
+aware of the `Tabular Data Package`_.  For the purposes of this APE we
+still will refer to the proposed standard as DTIF, but the TDP is very
+similar and already exists as a well-defined standard that we would
+*very much* like to leverage.
+
+The key issue is that it uses two files to represent the tabular data:
+
+- A header file with pure JSON and a reference to the data file name.
+- A data file with pure CSV and (presumably) no # comments or features
+  that otherwise deviate from strict CSV standards.
+
+Using two files instead of one complicates data management and allows for
+header and data files to become decoupled.  However, using pure JSON
+and CSV files does bring the advantage of enhanced interoperability.
+There is some heritage for the two (or more) file solution from CDS.
+So despite hesitation about going down this path, an honest discussion
+
+.. Note::
+   The subsequent example and details do not reflect consideration of
+   the `Tabular Data Package`_ format.  These will be modified if
+   needed based on community inputs on the direction to follow.
 
 Why JSON?
 ^^^^^^^^^^

--- a/APE6.rst
+++ b/APE6.rst
@@ -5,7 +5,7 @@ author: Tom Aldcroft
 
 date-created: 2014 April 12
 
-date-last-revised: 2014 September 5
+date-last-revised: 2014 December 28
 
 type: Standard Track
 
@@ -200,6 +200,9 @@ overall structure:
 - A CSV-formatted data section in which the first line contains the column names
   and subsequent lines contains the data values.
 
+Version 1.0 of the ECSV format specification and the reference Python
+implementation assumes ASCII-encoded header and data sections.  Support
+for unicode (in particular UTF-8) may be added in subsequent versions.
 
 Why YAML?
 ^^^^^^^^^^
@@ -427,6 +430,7 @@ the following rules:
 - A double quote character in a field must be represented by two double quote
   characters.
 
+
 Multidimensional columns
 """"""""""""""""""""""""
 
@@ -445,7 +449,6 @@ indicates the column is one element of a multidimensional column ``<name>``.
 The specifics might need iteration, but again the idea is to maintain the
 ability to always read a ECSV file with a simple CSV reader, even if using the
 results then takes more effort.
-
 
 Branches and pull requests
 --------------------------

--- a/APE6.rst
+++ b/APE6.rst
@@ -38,7 +38,7 @@ The well-known `XKCD comic <https://xkcd.com/927/>`_ aptly mocks the
 introduction of new standards.  Let's just stipulate that this standard may be a
 bad idea, but talk about it anyway.  Following the lead of the astronomical data
 community in recently documenting shortcomings of the FITS standard, we start by
-discussing existing widely-used standards and why they are substantially
+discussing existing widely-used standards and why they are
 lacking.
 
 CSV
@@ -339,6 +339,22 @@ standard CSV rules.
 In this example above the delimiter is the space character.  Details of
 delimiters, quote characters, etc that should be allowed / supported are TBD.
 
+Multidimensional columns
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+None of the available text data formats supports multidimensional columns
+with more than one element per row.  Although in many cases
+having such data would indicate using a binary storage format, there is
+utility in supporting this for cases where the column shape is "reasonable",
+perhaps with no more than about 10 elements.
+
+In this case one could store the individual data elements as a series of
+columns with a naming convention such as ``<name>__<index0>_<index1>_...``.
+In this case one would include a keyword in the column specification that
+indicates the column is one element of a multidimensional column ``<name>``.
+The specifics might need iteration, but again the idea is to maintain the
+ability to always read a DTIF file with a simple CSV reader, even if using
+the results then takes more effort.
 
 Branches and pull requests
 --------------------------

--- a/APE6.rst
+++ b/APE6.rst
@@ -352,14 +352,16 @@ required keywords and standard specifiers.
 
 Each line of the YAML-encoded data structure must start with the two
 characters ``# `` (hash followed by space) to indicate the presence of
-header content.  The first line which does not start with ``#``
-signifies the end of the header.  Subsequent lines starting with ``#``
-are treated as file comment lines.
+header content.  All content within this header section must be parseable
+as a single YAML document.  The first line which does not start with ``#``
+signifies the end of the header and the start of the data section.  Subsequent
+lines within the data section starting with ``#`` are to be ignored by the
+parser and not provided in the header output.
 
 Within the header section, lines which start with ``##`` are treated as
-comments and can be ignored by readers.  There is no requirement for
-ECSV writers to emit such comment data.  Relevant comment strings
-should be serialized within the ``meta`` keyword structure.
+comments and must be ignored by readers.  ECSV writers shall not emit such
+comment data.  Relevant comment strings should be serialized within the
+``meta`` keyword structure.
 
 Beyond the minimal standard, applications are free to
 create a custom data structure as needed using the top-level ``meta``
@@ -430,6 +432,9 @@ names formatted according to the CSV writer being used.  This allows
 most CSV reader applications to successfully read ECSV files and
 automatically infer the correct column names.  ECSV readers should
 validate that the column names in this line match those in the header.
+A mismatch of the number of columns will be an error.  If there is a
+name mismatch then it is recommended that the reader issue a warning,
+but implementations are free to be either less or more strict.
 
 Following the column name line the data values are serialized according to
 the following rules:
@@ -440,7 +445,8 @@ the following rules:
 - Any field may be quoted with double quotes.
 - Fields containing a line-break, double-quote, and/or the delimiter character
   must be quoted
-- Boolean fields are represented as the string ``False`` or ``True``.
+- Boolean fields are represented as the case-sensitive string ``False`` or
+  ``True``.
 - A double quote character in a field must be represented by two double quote
   characters.
 

--- a/APE6.rst
+++ b/APE6.rst
@@ -1,0 +1,211 @@
+Data Table Text Interchange Format
+----------------------------------
+
+author: Tom Aldcroft
+
+date-created: 2014 April 12
+
+date-last-revised: 2014 APR 12
+
+type: Standard Track
+
+status: Discussion
+
+
+Abstract
+--------
+
+This APE is primarily a specification of a new standard for the interchange of
+tabular data in a text-only format.  The proposed format handles the key issue
+of serializing column specifications and table metadata by using a JSON-encoded
+data structure which is included in the file as a series of ``#``-prefixed
+comment lines.  The actual tabular data are stored in a standard
+comma-separated-values (CSV) format, giving compatibility with a wide variety of
+non-specialized CSV table readers.  Using JSON makes it extremely easy for
+applications to read both the standardized data format elements (e.g. column
+name, type, description) as well as complex metadata structures.  Support for
+schemas to describe and validate the metadata is part of the standard along with
+support for non-ASCII unicode character encoding.
+
+The implementation in ``astropy.io.ascii`` is relatively straightforward and
+will provide a significant benefit of allowing text serialization of most astropy
+Table objects, persistent storage, and subsequent interchange with other users.
+
+Existing standards
+--------------------
+
+The well-known `XKCD comic <https://xkcd.com/927/>`_ aptly mocks the
+introduction of new standards.  Let's just stipulate that this standard may be a
+bad idea, but talk about it anyway.  Following the lead of the astronomical data
+community in recently documenting shortcomings of the FITS standard, we start by
+discussing existing widely-used standards and why they are substantially
+lacking.
+
+CSV
+^^^^^
+
+The `Comma-Separated-Values format
+<http://en.wikipedia.org/wiki/Comma-separated_values>`_ is probably the most
+common text-based method for representing data tables.  The proposed standard in
+APE6 leverages this universality by using this format for serializing
+the actual data values.
+
+As noted in the Wikipedia article, CSV is not a rigid standard despite some
+efforts in that direction.  Even the name "comma-separated" is misleading since
+tab-separated or whitespace-separated tabular data generally fall in this
+category.  Nevertheless nearly everyone with a computer has access to robust
+tools that can read and write CSV format tables, and CSV is a de-facto standard
+for importing and exporting tabular data to applications, including most
+spreadsheet applications like Excel.
+
+For science applications, pure CSV has a serious shortcoming in the complete
+lack of support for table metadata.  This is frequently not a showstopper but
+represents a serious limitation which has motivated alternate standards
+in the astronomical community.
+
+CDS / ApJ Machine Readable Table
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Centre de Données astronomiques de Strasbourg developed a `Standard for
+Documentation of Astronomical Catalogues
+<http://vizier.u-strasbg.fr/doc/catstd.htx>`_ which is very widely used.  The
+Astrophysical Journal has adopted this standard for formatting `machine readable
+tables <http://aas.org/authors/machine-readable-table-standards>`_ associated
+with journal articles.  The format is alternately referred to as the CDS or
+Machine Readable Table (MRT) format.
+
+The CDS format has reasonable support for basic table and column metadata,
+include column types, null values, range checking, units, and labels.  From
+its heritage as a catalog descriptor format, it includes table metadata
+like ADC_Keywords, Literature Reference, table description, authors, notes,
+and comments.  Within that context it provides a well-documented standard.
+
+However, the CDS format does not include support for keyword values like FITS, 
+nor arbitrary table metadata.  This limits the fidelity of serialization
+for tables that have rich metadata (e.g. WCS).
+
+As a tool for data interchange, CDS is far from ideal.  Despite the name "Machine
+Readable Table", the format is quite difficult for machines to read.  This
+stems from the format of the `ReadMe file
+<http://vizier.u-strasbg.fr/doc/catstd-3.1.htx>`_, which has a 
+non-regular format that requires tricky regex parsing and logic to fully interpret.
+
+A few options for `reading MRT files
+<https://aas.org/authors/machine-readable-table-programs>`_ are available, but
+none of them are full-featured.  [QUESTION: does TOPCAT directly read CDS?  It
+isn't explicitly listed as a supported format].  As far as we know the version
+in Astropy is the only one being currently maintained.  It supports much of the
+standard with regards to the data values and column definitions, but makes no
+attempt to parse any of the other table metadata.  Getting an MRT file directly
+into Excel is onerous.
+
+We are unaware of any publicly available application that can write in the CDS /
+MRT format, and instead authors rely on data translation by online tools or data
+service providers.
+
+IPAC
+^^^^^
+
+The `IPAC Table Format
+<http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/ipac_tbl.html>`_ is the
+standard for the NASA/IPAC Infrared Science Archive and is widely used.
+
+This format is more in line with FITS in terms of providing support for
+arbitrary keyword / value pairs and comment lines, along with specification of
+column names, data types, units, and null values.  The format is succinctly
+described in the standard page and is fairly straightforward to understand
+and implement.
+
+IPAC has a shortcoming as a generic data interchange format because of the
+specific serialization of the column specification.  Note that in the example
+below the comments are not part of the actual data file and are included for
+illustration purposes only::
+
+  \keyword = value                                                  # Keywords (optional)
+  \ Comment                                                         # Comments (optional)
+  |  name1    |  name2    | name3   |  name4   |     name5        | # Column Names (required)
+  |   double  |   double  |   int   |   real   |     char         | # Data Types (standard)
+  |   unit    |   unit    |   unit  |   unit   |     unit         | # Data Units (optional)
+  |   null    |   null    |   null  |   null   |     null         | # Null Values (optional)
+    165.466279  -34.704730      5      11.27      A string value    # Data Rows (1 required)
+    160.1231     -4.7           3       2.3          value          # Data Rows (1 required)
+
+In order to associate the columns names ``name1`` .. ``name5`` with the five
+data columns, the reader application has to have specific knowledge of the IPAC
+format.  Clearly providing full support for specific typing, units and
+null-value handling requires a dedicated reader, but a significant fraction of
+data tables do not require these and can make due with just column names and
+automatic type inference.  Supporting the common case of falling through to
+bare-bones CSV table support has value.
+
+Another issue illustrated above is that IPAC uses fixed-width formatting for the
+data values, so that if a generic CSV reader tries to parse this file it will
+find an inconsistency in the number of data columns between rows 1 and 2
+(because of the spaces in the ``name5`` column values).
+
+Supporting more complex metadata structures would be possible within the IPAC
+standard using keyword values, but it would be cumbersome and require inventing
+a custom serialization method to work within that confine.
+
+VOTable
+^^^^^^^^
+
+`VOTable <http://www.ivoa.net/documents/latest/VOT.html>`_ is by design a
+fully-flexible data format that can handle all of the needs for text
+serialization of complex data structures, including tablular data sets.  The
+issue in this context is in simplicity and data interchange with the broader
+community.  In essence if someone wants to read or write a VOTable then they
+must use one of a small number of implementations of this protocol.  It is not
+possible for someoneto directly read such a table into Excel.  Writing an
+implementation of VOTable in a new language (e.g. R, Julia, or Perl) to read/write
+VOTable is a major undertaking.
+
+A smaller issue is speed, since the VOTable format requires relatively complex
+parsing and validation for text serialization.
+
+Others
+^^^^^^^^
+
+We are not aware of other widely-used standards for text representation of
+tabular data.
+
+
+Detailed description
+---------------------
+
+
+Branches and pull requests
+--------------------------
+
+Any pull requests or development branches containing work on this APE should be
+linked to from here.  (An APE does not need to be implemented in a single pull
+request if it makes sense to implement it in discrete phases). If no code is yet
+implemented, just put "N/A"
+
+
+Implementation
+--------------
+
+This section lists the major steps required to implement the APE.  Where
+possible, it should be noted where one step is dependent on another, and which
+steps may be optionally omitted.  Where it makes sense, each  step should
+include a link related pull requests as the implementation progresses.
+
+
+Backward compatibility
+----------------------
+
+This section describes the ways in which the APE breaks backward compatibility.
+
+
+Alternatives
+------------
+
+If there were any alternative solutions to solving the same problem, they should
+be discussed here, along with a justification for the chosen approach.
+
+
+Decision rationale
+------------------
+
+<To be filled in when the APE is accepted or rejected>

--- a/APE6.rst
+++ b/APE6.rst
@@ -1,5 +1,5 @@
 Enhanced Character-Separated-Values format
------------------------------------
+------------------------------------------
 
 author: Tom Aldcroft
 
@@ -227,6 +227,10 @@ is highly-recommended that applications format the YAML header to be legible
 to humans.  This is important because a key feature of YAML is that it is
 meant to be easily readable, and thus modifiable, by humans.
 
+The highly readable nature of YAML is key driver for using this over JSON.
+In simple cases the column definitions serialize on a single line which
+makes for a compact and useful representation.
+
 Example
 ^^^^^^^^^^
 
@@ -377,7 +381,8 @@ Each column specifier is a dictionary structure with the following keys:
   Column data type.  Allowed types are: ``bool``, ``int8``,
   ``int16``, ``int32``, ``int64``, ``uint8``, ``uint16``, ``uint32``,
   ``uint64``, ``float16``, ``float32``, ``float64``, ``float128``,
-  ``complex64``, ``complex128``, ``complex256``, and ``string8``.
+  ``complex64``, ``complex128``, ``complex256``, and ``string``.
+  Some implementations may not support all types.
 
 ``unit``: string, optional
    Data unit (unit system could be part of schema?).
@@ -412,11 +417,20 @@ validate that the column names in this line match those in the header.
 Following the column name line the data values are serialized according to
 the following rules:
 
-In this example above the delimiter is the space character.  Details of
-delimiters, quote characters, etc that should be allowed / supported are TBD.
+- Each row must contain the same number of delimiter-separated fields.
+- Fields are separated by the delimiter character, which can be either the
+  space or comma character.
+- Any field may be quoted with double quotes.
+- Fields containing a line-break, double-quote, and/or the delimiter character
+  must be quoted
+- Boolean fields are represented as the string ``False`` or ``True``.
+- A double quote character in a field must be represented by two double quote
+  characters.
 
 Multidimensional columns
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Multidimensional columns are not supported in version 1.0 of the ECSV format.
 
 None of the available text data formats supports multidimensional columns
 with more than one element per row.  Although in many cases
@@ -424,13 +438,14 @@ having such data would indicate using a binary storage format, there is
 utility in supporting this for cases where the column shape is "reasonable",
 perhaps with no more than about 10 elements.
 
-In this case one could store the individual data elements as a series of
-columns with a naming convention such as ``<name>__<index0>_<index1>_...``.
-In this case one would include a keyword in the column specification that
+One possible solution is to store the individual data elements as a series of
+columns with a naming convention such as ``<name>__<index0>_<index1>_...``.  In
+this case one would include a keyword in the column specification that
 indicates the column is one element of a multidimensional column ``<name>``.
 The specifics might need iteration, but again the idea is to maintain the
-ability to always read a ECSV file with a simple CSV reader, even if using
-the results then takes more effort.
+ability to always read a ECSV file with a simple CSV reader, even if using the
+results then takes more effort.
+
 
 Branches and pull requests
 --------------------------

--- a/APE6.rst
+++ b/APE6.rst
@@ -89,8 +89,7 @@ non-regular format that requires tricky regex parsing and logic to fully interpr
 
 A few options for `reading MRT files
 <https://aas.org/authors/machine-readable-table-programs>`_ are available, but
-none of them are full-featured.  [QUESTION: does TOPCAT directly read CDS?  It
-isn't explicitly listed as a supported format].  As far as we know the version
+none of them are full-featured.  As far as we know the version
 in Astropy is the only one being currently maintained.  It supports much of the
 standard with regards to the data values and column definitions, but makes no
 attempt to parse any of the other table metadata.  Getting an MRT file directly
@@ -153,7 +152,7 @@ serialization of complex data structures, including tablular data sets.  The
 issue in this context is in simplicity and data interchange with the broader
 community.  In essence if someone wants to read or write a VOTable then they
 must use one of a small number of implementations of this protocol.  It is not
-possible for someoneto directly read such a table into Excel.  Writing an
+possible for someone to directly read such a table into Excel.  Writing an
 implementation of VOTable in a new language (e.g. R, Julia, or Perl) to read/write
 VOTable is a major undertaking.
 
@@ -360,7 +359,7 @@ Standard keywords are:
 
 ``delimiter``: one-character string, optional, default=``space``
    Delimiter character used to separate the data fields.  Allowed
-   delimiter values are the characters ``space`` or ``comma``.
+   delimiter values are the single characters ``space`` or ``comma``.
 
 ``meta``: structure, optional
    Table meta-data as an arbitrary data structure consisting


### PR DESCRIPTION
APE6 is primarily a specification of a new standard for the interchange of tabular data in a text-only format. The proposed format handles the key issue of serializing column specifications and table metadata by using a JSON-encoded data structure which is included in the file as a series of #-prefixed comment lines. The actual tabular data are stored in a standard comma-separated-values (CSV) format, giving compatibility with a wide variety of non-specialized CSV table readers. Using JSON makes it extremely easy for applications to read both the standardized data format elements (e.g. column name, type, description) as well as complex metadata structures. Support for schemas to describe and validate the metadata is part of the standard along with support for non-ASCII unicode character encoding.

The implementation in astropy.io.ascii is relatively straightforward and will provide a significant benefit of allowing text serialization of most astropy Table objects, persistent storage, and subsequent interchange with other users.