### PR TITLE
Add detail to Decision rationale in template

### DIFF
--- a/APEtemplate.rst
+++ b/APEtemplate.rst
@@ -61,4 +61,4 @@ be discussed here, along with a justification for the chosen approach.
 Decision rationale
 ------------------
 
-<To be filled in when the APE is accepted or rejected>
+<To be filled in by the coordinating committee when the APE is accepted or rejected>


### PR DESCRIPTION
To make it more clear to APE authors about the final process for the `Decision rationale` section.