### PR TITLE
Update APE6.rst to fix one example

### DIFF
--- a/APE6.rst
+++ b/APE6.rst
@@ -317,7 +317,7 @@ Now we write the table to standard out::
   # %ECSV 0.9
   # ---
   # datatype:
-  # - {name: a, unit: m / s, type: int64, format: '%5.2f', description: Column A}
+  # - {name: a, unit: m / s, datatype: int64, format: '%5.2f', description: Column A}
   # - name: b
   #   datatype: int64
   #   meta:


### PR DESCRIPTION
The main fix is that for columns "type" doesn't work, it has to be "datatype".

Related: https://github.com/astropy/astropy/issues/5450

cc @taldcroft 
