### PR TITLE
Migrate README.rst to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-APEs: Astropy Proposals for Enhancement
----------------------------------------
+# APEs: Astropy Proposals for Enhancement
 
 APEs are documents to address non-trivial enhancements that require discussion
 and thought beyond a single Pull Request. This is intended to mirror the
@@ -9,39 +8,24 @@ Discussion is expected to take place using existing mechanisms (astropy-dev,
 github, hangouts, etc), and eventually a decision is made regarding whether the
 proposal should be accepted, rejected, or modified.
 
-Accepted APEs
-^^^^^^^^^^^^^
+## Accepted APEs
 
-=== =================================================== ===========
-#     Title                                             Date
-=== =================================================== ===========
-1   `APE Purpose and Process`_                          2013-Nov-08
-2   `Astropy Release Cycle and Version Numbering`_      2013-Dec-11
-3   `Configuration`_                                    2013-Dec-10
-4   `Astropy Setup Helpers`_                            2014-Jun-28
-5   `Coordinates Subpackage Plan`_                      2014-Jan-22
-6   `Enhanced Character Separated Values table format`_ 2015-Jan-26
-7   `NDData Plan`_                                      2014-Dec-17
-8   `Astropy Community Code of Conduct`_                2015-May-04
-10  `Roadmap for Python 3-only support`_                2016-Aug-22
-=== =================================================== ===========
+| # | Title | Date |
+| :--- | :--- | :--- |
+| 1   | [APE Purpose and Process](APE1.rst)                          | 2013-Nov-08 |
+| 2   | [Astropy Release Cycle and Version Numbering](APE2.rst)      | 2013-Dec-11 |
+| 3   | [Configuration](APE3.rst)                                    | 2013-Dec-10 |
+| 4   | [Astropy Setup Helpers](APE4.rst)                            | 2014-Jun-28 |
+| 5   | [Coordinates Subpackage Plan](APE5.rst)                      | 2014-Jan-22 |
+| 6   | [Enhanced Character Separated Values table format](APE6.rst) | 2015-Jan-26 |
+| 7   | [NDData Plan](APE7.rst)                                      | 2014-Dec-17 |
+| 8   | [Astropy Community Code of Conduct](APE8.rst)                | 2015-May-04 |
+| 10  | [Roadmap for Python 3-only support](APE10.rst)               | 2016-Aug-22 |
 
-.. _APE Purpose and Process: https://github.com/astropy/astropy-APEs/blob/master/APE1.rst
-.. _Astropy Release Cycle and Version Numbering: https://github.com/astropy/astropy-APEs/blob/master/APE2.rst
-.. _Configuration: https://github.com/astropy/astropy-APEs/blob/master/APE3.rst
-.. _Astropy Setup Helpers: https://github.com/astropy/astropy-APEs/blob/master/APE4.rst
-.. _Coordinates Subpackage Plan: https://github.com/astropy/astropy-APEs/blob/master/APE5.rst
-.. _Enhanced Character Separated Values table format: https://github.com/astropy/astropy-APEs/blob/master/APE6.rst
-.. _NDData Plan: https://github.com/astropy/astropy-APEs/blob/master/APE7.rst
-.. _Astropy Community Code of Conduct: https://github.com/astropy/astropy-APEs/blob/master/APE8.rst
-.. _Roadmap for Python 3-only support: https://github.com/astropy/astropy-APEs/blob/master/APE10.rst
+## Proposing a new APE
 
-
-Proposing a new APE
-^^^^^^^^^^^^^^^^^^^
-
-New APEs should be created using the ``APEtemplate.rst`` file in this repository.
-Just fork the repository, copy ``APEtemplate.rst`` to ``APE#.rst`` and issue a
+New APEs should be created using the `APEtemplate.rst` file in this repository.
+Just fork the repository, copy `APEtemplate.rst` to `APE#.rst` and issue a
 PR with that file once you've written it up.  Be sure to look through the PRs in
 this repo first so that you choose an APE# that reflects both those that are in
 the repository *and* those that are under discussion.
@@ -57,8 +41,7 @@ acceptance. For serious consideration it is usually good to show that detailed
 technical aspects have been played with in real code rather (even if it isn't a
 complete implementation).
 
-Accepting APEs
-^^^^^^^^^^^^^^
+## Accepting APEs
 
 The final decision on accepting or rejecting APEs lies with the Astropy
 Coordination Committee.  Once the community discussion on the APE has wound


### PR DESCRIPTION
This solves the issue of relative links in the APEs table by migrating the README from RST to markdown.  I also think markdown is nicer for something like this.