### PR TITLE
Update APE10 to have higher minimum python 3 versions

### DIFF
--- a/APE10.rst
+++ b/APE10.rst
@@ -90,12 +90,12 @@ versions:
 ==========    ===============================
 Version       Minimum required Python version
 ==========    ===============================
-v2.0 - LTS    Python 2.7 or Python 3.3+
-v3.0          Python 3.4+
-v3.1          Python 3.4+
-v3.2          Python 3.4+
-v3.3          Python 3.5+
-v4.0 - LTS    Python 3.5+
+v2.0 - LTS    Python 2.7 or Python 3.4+
+v3.0          Python 3.5+
+v3.1          Python 3.5+
+v3.2          Python 3.5+
+v3.3          Python 3.6+
+v4.0 - LTS    Python 3.6+
 ==========    ===============================
 
 Implementation
@@ -210,8 +210,8 @@ There are several benefits to following the plan proposed above:
 
 * We will be able to start using Python 3-only features internally, including
   for example function annotations (e.g., for units), matrix multiplication
-  (e.g., for coordinates; note that this will only be possible once we support
-  only Python 3.5+)
+  (e.g., for coordinates; note that this will only be possible with Python 3.5+,
+  which in part drives that as minimum version for astropy 3.0)
 
 * Since we will need to keep adding Python 3.x releases to the continuous
   integration over the coming years, we will at least be able to remove Python
@@ -256,3 +256,11 @@ feedback (some of which led to minor adjustments particularly regarding the PyPI
 issues).  Because of this apparent support by the community and agreement from
 the coordination committee with the goals of this APE, it was accepted Aug 22,
 2016.
+
+Updates after acceptance of the APE
+-----------------------------------
+In further discussions (https://github.com/astropy/astropy/issues/6000), it was
+noted that one should not aim to support versions of python that will reach end
+of life during the time an astropy version is supported. In particular, python
+3.3 would reach end-of-life only 3 months after the nominal astropy 2.0 release.
+Hence, all minimum versions of python 3 were increased by one minor version.

--- a/APE10.rst
+++ b/APE10.rst
@@ -5,7 +5,9 @@ author: Tom Robitaille
 
 date-created: 2016 July 13
 
-date-last-revised: 2016 August 22
+date-last-revised: 2017 May 12
+
+date-accepted: 2016 August 22
 
 type: Process
 

--- a/APE10.rst
+++ b/APE10.rst
@@ -262,7 +262,7 @@ the coordination committee with the goals of this APE, it was accepted Aug 22,
 Updates after acceptance of the APE
 -----------------------------------
 In further discussions (https://github.com/astropy/astropy/issues/6000), it was
-noted that one should not aim to support versions of python that will reach end
-of life during the time an astropy version is supported. In particular, python
+noted that one should not aim to support versions of Python that will reach end
+of life during the time an astropy version is supported. In particular, Python
 3.3 would reach end-of-life only 3 months after the nominal astropy 2.0 release.
-Hence, all minimum versions of python 3 were increased by one minor version.
+Hence, all minimum versions of Python 3 were increased by one minor version.


### PR DESCRIPTION
Following discussion in https://github.com/astropy/astropy/issues/6000: change the minimum version for python 3 such that the minimum python version will be supported for (most of) the lifetime of any astropy release.