### PR TITLE
Proposal: adopt the Creative Commons Attribution 4.0 International license

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,0 +1,6 @@
+=======
+License
+=======
+
+The content of this repository is licensed under the `Creative Commons Attribution 4.0 International (CC BY 4.0) license <https://creativecommons.org/licenses/by/4.0/>`_.
+


### PR DESCRIPTION
This pull request proposes that the astropy-APEs repository adopts the [CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0/) that allows people to share and adapt the material as long as appropriate credit is given, a link to the license is provided, and an indication is given if changes were made.  

Alternative licenses include other [Creative Commons licenses](https://creativecommons.org/licenses/) that have more restrictions on sharing, and the [CC0 license](https://creativecommons.org/share-your-work/public-domain/cc0/) which is very close to putting something in the public domain.

I had been hoping to adapt the APE template for use in a different project and noticed that this repository lacks a license, so I'd be grateful if one were added!

Many thanks!
-Nick


