### PR TITLE
Make dates consistent between APEs

### DIFF
--- a/APE1.rst
+++ b/APE1.rst
@@ -7,6 +7,8 @@ date-created: 2013 October 11
 
 date-last-revised: 2013 November 8
 
+date-accepted: 2013 November 8
+
 type: Process
 
 status: Accepted

--- a/APE10.rst
+++ b/APE10.rst
@@ -5,7 +5,7 @@ author: Tom Robitaille
 
 date-created: 2016 July 13
 
-date-last-revised: 2017 May 12
+date-last-revised: 2017 May 30
 
 date-accepted: 2016 August 22
 

--- a/APE12.rst
+++ b/APE12.rst
@@ -5,12 +5,13 @@ author: Stuart Mumford, Thomas Robitaille
 
 date-created: 2016 November 17
 
-date-last-revised: 2017 January 24
+date-last-revised: 2017 March 28
+
+date-accepted: 2017 March 28
 
 type: Standard Track
 
-status: Discussion
-
+status: Accepted
 
 Abstract
 --------
@@ -96,7 +97,7 @@ non-default branch.
     project_url [http://astropy.org]: http://cadair.com
 
     project_version [0.0.dev]: 0.0.1.dev
-   
+
     include_example_code [y]:
 
     include_cextern_folder [n]:

--- a/APE2.rst
+++ b/APE2.rst
@@ -7,6 +7,8 @@ date-created: 2013 November 18
 
 date-last-revised: 2013 December 11
 
+date-accepted: 2013 December 10
+
 type: Process
 
 status: Accepted

--- a/APE3.rst
+++ b/APE3.rst
@@ -3,7 +3,11 @@ Configuration
 
 author: Michael Droettboom
 
-date: 2013-12-10
+date-created: 2013 December 10
+
+date-last-revised: 2014 April 30
+
+date-accepted: 2014 April 30
 
 type: Standard Track
 

--- a/APE4.rst
+++ b/APE4.rst
@@ -3,9 +3,11 @@ Astropy Setup Helpers
 
 author: Erik M. Bray
 
-date-created: 2013-12-26
+date-created: 2013 December 26
 
-date-last-revised: 2014-06-28
+date-last-revised: 2014 June 28
+
+date-accepted: 2014 June 28
 
 type: Process
 

--- a/APE5.rst
+++ b/APE5.rst
@@ -3,7 +3,11 @@ Coordinates Subpackage Plan
 
 authors: Erik Tollerud, Adrian Price-Whelan, Thomas Aldcroft, Thomas Robitalle
 
-date: 2014 January 22
+date-created: 2014 January 22
+
+date-last-revised: 2014 March 9
+
+date-accepted: 2014 March 9
 
 type: Standard Track
 

--- a/APE6.rst
+++ b/APE6.rst
@@ -5,14 +5,13 @@ author: Tom Aldcroft
 
 date-created: 2014 April 12
 
-date-last-revised: 2015 January 26
+date-last-revised: 2017 November 8
+
+date-accepted: 2015 January 26
 
 type: Standard Track
 
 status: Accepted
-
-version: 0.9
-
 
 Abstract
 --------

--- a/APE7.rst
+++ b/APE7.rst
@@ -3,9 +3,11 @@ NDData Plan
 
 authors: Thomas Robitaille, Perry Greenfield, Matt Craig
 
-date-created: 2014 October 30
+date-created: 2014 October 2
 
 date-last-revised: 2014 December 17
+
+date-accepted: 2014 December 17
 
 type: Standard Track
 

--- a/APE8.rst
+++ b/APE8.rst
@@ -5,12 +5,13 @@ authors: Kelle Cruz, Alex Hagen, Thomas Robitaille, Erik Tollerud, Alexa Villaum
 
 date-created: 2015 May 4
 
-date-last-revised: 2015 May 4
+date-last-revised: 2015 May 17
+
+date-accepted: 2015 May 17
 
 type: Informational
 
-status: Discussion
-
+status: Accepted
 
 Abstract
 --------

--- a/APEtemplate.rst
+++ b/APEtemplate.rst
@@ -7,6 +7,8 @@ date-created: 2013 November 5 <replace with the date you submit the APE>
 
 date-last-revised: 2013 December 17 <keep this up to date anytime something changes>
 
+date-accepted: 2014 January 20 <replace with accepted date>
+
 type: <one of these three: Standard Track, Informational, Process>
 
 status: Discussion


### PR DESCRIPTION
Some APEs were missing accepted dates. I would like to suggest that changes such as this don't warrant a revision update though.