### PR TITLE
Removing 3rd 't' in cookiecutter command

### DIFF
--- a/APE12.rst
+++ b/APE12.rst
@@ -144,7 +144,7 @@ A version of the package template converted to a Cookiecutter project is `here
 tested by installing the cookiecutter package from pip or conda-forge and
 running::
 
-  cookiecuttter -c cookiecutter gh:cadair/package-template
+  cookiecutter -c cookiecutter gh:cadair/package-template
 
 
 Implementation


### PR DESCRIPTION
Extremely minor fix.
Currently, cutting and pasting the recommended command to run cookiecutter does not work as the command has too many ts. 