### PR TITLE
Add step to accepting instructions of emailing astropy-dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,11 +101,13 @@ or rejection.  One of the committee members should then:
    discussion as relevant.
 2. Update the "date-last-revised" to the day of merging and "status" to
    "Accepted" or "Rejected".
-3. If the APE is accepted, add a commit to the APE which puts the APE into the
+3. If necessary, rename the APE file to be ``APE##.rst``, where ## is the next
+   free number on the list of APEs.
+4. If the APE is accepted, add a commit to the APE which puts the APE into the
    "Accepted APEs" table of the repository's README.
-4. Merge the PR with the above changes.
-5. Upload the APE to Zenodo to give it a DOI (see next section).
-6. Send an email to `astropy-dev <https://groups.google.com/forum/#!forum/astropy-dev/>`_ announcing the acceptance (In general this should just point to the accepted APE rather than providing additional decision rationale).
+5. Merge the PR with the above changes.
+6. Upload the APE to Zenodo to give it a DOI (see next section).
+7. Send an email to `astropy-dev <https://groups.google.com/forum/#!forum/astropy-dev/>`_ announcing the acceptance (In general this should just point to the accepted APE rather than providing additional decision rationale).
 
 Uploading an APE to Zenodo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,9 @@ or rejection.  One of the committee members should then:
    "Accepted APEs" table of the repository's README.
 5. Merge the PR with the above changes.
 6. Upload the APE to Zenodo to give it a DOI (see next section).
-7. Send an email to `astropy-dev <https://groups.google.com/forum/#!forum/astropy-dev/>`_ announcing the acceptance (In general this should just point to the accepted APE rather than providing additional decision rationale).
+7. Send an email to `astropy-dev <https://groups.google.com/forum/#!forum/astropy-dev/>`_
+   announcing the acceptance (In general this should just point to the accepted
+   APE rather than providing additional decision rationale).
 
 Uploading an APE to Zenodo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Accepted APEs
 5   `Coordinates Subpackage Plan`_                      2014-Jan-22 |APE 5 DOI|
 6   `Enhanced Character Separated Values table format`_ 2015-Jan-26 |APE 6 DOI|
 7   `NDData Plan`_                                      2014-Dec-17 |APE 7 DOI|
-8   `Astropy Community Code of Conduct`_                2015-May-04 |APE 8 DOI| 
+8   `Astropy Community Code of Conduct`_                2015-May-04 |APE 8 DOI|
 10  `Roadmap for Python 3-only support`_                2016-Aug-22 |APE 10 DOI|
 12  `Using Cookiecutter for the package-template`_      2017-Mar-28 |APE 12 DOI|
 === =================================================== =========== ============
@@ -105,6 +105,9 @@ or rejection.  One of the committee members should then:
    "Accepted APEs" table of the repository's README.
 4. Merge the PR with the above changes.
 5. Upload the APE to Zenodo to give it a DOI (see next section).
+6. Send an email to astropy-dev announcing the acceptance (In general this
+   should just point to the accepted APE rather than providing additional
+   decision rationale).
 
 Uploading an APE to Zenodo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ or rejection.  One of the committee members should then:
    "Accepted APEs" table of the repository's README.
 4. Merge the PR with the above changes.
 5. Upload the APE to Zenodo to give it a DOI (see next section).
-6. Send an email to astropy-dev announcing the acceptance (In general this
+6. Send an email to `astropy-dev <https://groups.google.com/forum/#!forum/astropy-dev/>`_ announcing the acceptance (In general this
    should just point to the accepted APE rather than providing additional
    decision rationale).
 

--- a/README.rst
+++ b/README.rst
@@ -105,9 +105,7 @@ or rejection.  One of the committee members should then:
    "Accepted APEs" table of the repository's README.
 4. Merge the PR with the above changes.
 5. Upload the APE to Zenodo to give it a DOI (see next section).
-6. Send an email to `astropy-dev <https://groups.google.com/forum/#!forum/astropy-dev/>`_ announcing the acceptance (In general this
-   should just point to the accepted APE rather than providing additional
-   decision rationale).
+6. Send an email to `astropy-dev <https://groups.google.com/forum/#!forum/astropy-dev/>`_ announcing the acceptance (In general this should just point to the accepted APE rather than providing additional decision rationale).
 
 Uploading an APE to Zenodo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Just what it says... we (coordination committee) realized this step was desired but missing from the directions.