### PR TITLE
update APE10 for new release calendar

### DIFF
--- a/APE10.rst
+++ b/APE10.rst
@@ -5,7 +5,7 @@ author: Tom Robitaille
 
 date-created: 2016 July 13
 
-date-last-revised: 2017 May 30
+date-last-revised: 2018 Mar 19
 
 date-accepted: 2016 August 22
 
@@ -63,10 +63,10 @@ Version      Planned release date     Notes
 v1.3         December 2016
 v2.0 - LTS   June 2017                Supported with bug fixes until end of 2019
 v3.0         December 2017            First release to support only Python 3+
-v3.1         June 2018
-v3.2         December 2018
-v3.3         June 2019
-v4.0 - LTS   December 2019            Supported with bug fixes for two years
+v3.1         October 2018
+v3.2         April 2019
+v3.3         October 2019
+v4.0 - LTS   April 20120              Supported with bug fixes for two years
 ==========   ======================   ==========================================
 
 Note that v1.0, v2.0, and v4.0 are marked as long-term support releases (LTS),
@@ -266,3 +266,6 @@ noted that one should not aim to support versions of Python that will reach end
 of life during the time an astropy version is supported. In particular, Python
 3.3 would reach end-of-life only 3 months after the nominal astropy 2.0 release.
 Hence, all minimum versions of Python 3 were increased by one minor version.
+
+After v3.0, a decision was made to adjust the release calendar by +3 months.  The
+table above has been updated appropriately.

--- a/APE10.rst
+++ b/APE10.rst
@@ -66,7 +66,7 @@ v3.0         December 2017            First release to support only Python 3+
 v3.1         October 2018
 v3.2         April 2019
 v3.3         October 2019
-v4.0 - LTS   April 20120              Supported with bug fixes for two years
+v4.0 - LTS   April 2020               Supported with bug fixes for two years
 ==========   ======================   ==========================================
 
 Note that v1.0, v2.0, and v4.0 are marked as long-term support releases (LTS),

--- a/APE10.rst
+++ b/APE10.rst
@@ -63,10 +63,9 @@ Version      Planned release date     Notes
 v1.3         December 2016
 v2.0 - LTS   June 2017                Supported with bug fixes until end of 2019
 v3.0         December 2017            First release to support only Python 3+
-v3.1         October 2018
-v3.2         April 2019
-v3.3         October 2019
-v4.0 - LTS   April 2020               Supported with bug fixes for two years
+v3.1         November 2018            (Gap due to changes in release phase)
+v3.2         May 2019
+v4.0 - LTS   November 2019            Supported with bug fixes for two years
 ==========   ======================   ==========================================
 
 Note that v1.0, v2.0, and v4.0 are marked as long-term support releases (LTS),
@@ -267,5 +266,7 @@ of life during the time an astropy version is supported. In particular, Python
 3.3 would reach end-of-life only 3 months after the nominal astropy 2.0 release.
 Hence, all minimum versions of Python 3 were increased by one minor version.
 
-After v3.0, a decision was made to adjust the release calendar by +3 months.  The
-table above has been updated appropriately.
+After v3.0, a decision was made to adjust the release calendar by +3 months.
+The table above has been updated appropriately.  v3.3 was also removed on this
+basis, as the timing for the end of Python 2.x support is better aligned with an
+end-of-2019 4.0 release.


### PR DESCRIPTION
This is a small update to APE10 that accounts for the new release calendar after the +3 month change to avoid the holidays.  The coordination committee approved this change in a committee meeting this week.

One thing to bear in mind: this makes the v4.0 release (the first LTS that's py3-only) in 2020 instead of the end of 2019.  If I take this literally, that means there's a 3 month LTS gap.  @astrofrog (as APE10's author) should clarify: should I also update the "period of support" for v2.0 to go to then?  I think this is not really a big deal because the Python devs have been a bit ambiguous about exactly when py2 support ends (i.e. exactly when in "2020" the ending is) - so we can play it by ear a bit if necessary.