### PR TITLE
Update APE1 to include procedures for updating APEs

### DIFF
--- a/APE1.rst
+++ b/APE1.rst
@@ -81,7 +81,7 @@ APE-able. Posting to the astropy-dev mailing list is the best way to go about
 doing this.
 
 Following a discussion on astropy-dev, the proposal should be submitted as a
-Pull Request to astropy-APEs with the name APE<n>.rst where <n> is an
+pull request to astropy-APEs with the name APE<n>.rst where <n> is an
 appropriately assigned number. The draft must use the APEtemplate.rst file.
 That a formal proposal has been submitted as a PR should be announced to the
 astropy-dev list.
@@ -146,7 +146,7 @@ An APE can be modified, with one person acting as "champion" for the APE update.
 Similar to the APE development procedure, the update champion should discuss
 their desired changes with the Astropy community (e.g., through the astropy-dev
 mailing list). Following a discussion on astropy-dev, the APE update should be
-submitted as a Pull Request which should be advertised on astropy-dev.
+submitted as a pull request which should be advertised on astropy-dev.
 
 The APE should be modified directly without annotating the changes. If not
 already listed, the update champion can add themselves to the author list for
@@ -155,11 +155,11 @@ be added to the bottom of the APE (if not already there) with a bullet point
 list of dates which link to the DOI of the previous versions of APEs.
 
 The Astropy Coordinating Committee is responsible for reviewing and ultimately
-accepting Pull Requests for changes to individual APEs, unless otherwise
+accepting pull requests for changes to individual APEs, unless otherwise
 specified within the APE document of interest. For non-trivial changes,
 community consensus should generally be reached before acceptance.
 
-Branches and Pull requests
+Branches and Pull Requests
 --------------------------
 
 N/A

--- a/APE1.rst
+++ b/APE1.rst
@@ -146,7 +146,7 @@ Modifications to an APE
 
 An APE can be modified, with one person acting as "champion" for the
 APE update. Similar to the APE development procedure, the update
-champion should discuss their desired changes with the astropy
+champion should discuss their desired changes with the Astropy
 community (e.g., through the astropy-dev mailing list).
 
 Following a discussion on astropy-dev, the APE update shall be

--- a/APE1.rst
+++ b/APE1.rst
@@ -188,4 +188,4 @@ The coordinating committee thought it was a honking great idea.
 Previous versions of this APE
 -----------------------------
 
-* 2013-11-08 [`DOI <https://zenodo.org/record/1043886>`_] [`GitHub <https://github.com/astropy/astropy-APEs/blob/42951733ac42c0ea178d8df30705274a43c93091/APE1.rst>`_]
+* 2013-11-08 [`DOI <http://doi.org/10.5281/zenodo.1043886>`_] [`GitHub <https://github.com/astropy/astropy-APEs/blob/42951733ac42c0ea178d8df30705274a43c93091/APE1.rst>`_]

--- a/APE1.rst
+++ b/APE1.rst
@@ -5,7 +5,7 @@ author: Perry Greenfield, Lia Corrales
 
 date-created: 2013 October 11
 
-date-last-revised: 2020 July
+date-last-revised: 2020 July 22
 
 date-accepted: 2013 November 8
 
@@ -142,7 +142,7 @@ An APE's status can
 Modifications to an APE
 .......................
 
-**Addendum: July 2020**
+**Addendum: July 22, 2020**
 
 An APE can be modified, with one person acting as "champion" for the
 APE update. Similar to the APE development procedure, the update

--- a/APE1.rst
+++ b/APE1.rst
@@ -152,7 +152,8 @@ The APE should be modified directly without annotating the changes. If not
 already listed, the update champion can add themselves to the author list for
 the APE being updated. A new section, **Previous versions of this APE** should
 be added to the bottom of the APE (if not already there) with a bullet point
-list of dates which link to the DOI of the previous versions of APEs.
+list of dates which link to the DOI of the previous versions of APEs as well as
+links to the merge commits of the APEs.
 
 The Astropy Coordinating Committee is responsible for reviewing and ultimately
 accepting pull requests for changes to individual APEs, unless otherwise
@@ -187,4 +188,4 @@ The coordinating committee thought it was a honking great idea.
 Previous versions of this APE
 -----------------------------
 
-* `2013-11-08 <https://zenodo.org/record/1043886>`_
+* 2013-11-08 [`DOI <https://zenodo.org/record/1043886>`_] [`GitHub <https://github.com/astropy/astropy-APEs/blob/42951733ac42c0ea178d8df30705274a43c93091/APE1.rst>`_]

--- a/APE1.rst
+++ b/APE1.rst
@@ -1,7 +1,7 @@
 APE Purpose and Process
 -----------------------
 
-author: Perry Greenfield, Lia Corrales, Thomas Robitaille
+author: Perry Greenfield
 
 date-created: 2013 October 11
 
@@ -12,6 +12,8 @@ date-accepted: 2013 November 8
 type: Process
 
 status: Accepted
+
+revised-by: Lia Corrales, Thomas Robitaille - 2021 February 26 - Added APE modification process
 
 Abstract
 --------
@@ -142,7 +144,7 @@ An APE's status can
 Modifications to an APE
 .......................
 
-An APE can be modified, with one person acting as "champion" for the APE update.
+An APE can be modified, with one person acting as champion for the APE update.
 Similar to the APE development procedure, the update champion should discuss
 their desired changes with the Astropy community (e.g., through the astropy-dev
 mailing list). Following a discussion on astropy-dev, the APE update should be
@@ -155,10 +157,8 @@ be added to the bottom of the APE (if not already there) with a bullet point
 list of dates which link to the DOI of the previous versions of APEs as well as
 links to the merge commits of the APEs.
 
-The Astropy Coordinating Committee is responsible for reviewing and ultimately
-accepting pull requests for changes to individual APEs, unless otherwise
-specified within the APE document of interest. For non-trivial changes,
-community consensus should generally be reached before acceptance.
+The review process is the same as for a newly-proposed APE as described in the
+**APE Review** section above.
 
 Branches and Pull Requests
 --------------------------

--- a/APE1.rst
+++ b/APE1.rst
@@ -1,11 +1,11 @@
 APE Purpose and Process
 -----------------------
 
-author: Perry Greenfield, Lia Corrales
+author: Perry Greenfield, Lia Corrales, Thomas Robitaille
 
 date-created: 2013 October 11
 
-date-last-revised: 2020 July 22
+date-last-revised: 2021 February 26
 
 date-accepted: 2013 November 8
 
@@ -142,24 +142,22 @@ An APE's status can
 Modifications to an APE
 .......................
 
-**Addendum: July 22, 2020**
+An APE can be modified, with one person acting as "champion" for the APE update.
+Similar to the APE development procedure, the update champion should discuss
+their desired changes with the Astropy community (e.g., through the astropy-dev
+mailing list). Following a discussion on astropy-dev, the APE update should be
+submitted as a Pull Request which should be advertised on astropy-dev.
 
-An APE can be modified, with one person acting as "champion" for the
-APE update. Similar to the APE development procedure, the update
-champion should discuss their desired changes with the Astropy
-community (e.g., through the astropy-dev mailing list).
+The APE should be modified directly without annotating the changes. If not
+already listed, the update champion can add themselves to the author list for
+the APE being updated. A new section, **Previous versions of this APE** should
+be added to the bottom of the APE (if not already there) with a bullet point
+list of dates which link to the DOI of the previous versions of APEs.
 
-Following a discussion on astropy-dev, the APE update shall be
-submitted as a Pull Request. The submission of the Pull Request should
-be announced formally on the astropy-dev list before they are
-accepted. If not already listed, the update champion can add
-themselves to the author list for the APE being updated. When
-appropriate, major changes to an APE document are encouraged to be
-clearly labeled as an addendum.
-
-The Astropy Coordinating Committee is responsible for reviewing and
-ultimately accepting Pull Requests for changes to individual APEs,
-unless otherwise specified within the APE document of interest.
+The Astropy Coordinating Committee is responsible for reviewing and ultimately
+accepting Pull Requests for changes to individual APEs, unless otherwise
+specified within the APE document of interest. For non-trivial changes,
+community consensus should generally be reached before acceptance.
 
 Branches and Pull requests
 --------------------------
@@ -185,3 +183,8 @@ Decision Rationale
 ------------------
 
 The coordinating committee thought it was a honking great idea.
+
+Previous versions of this APE
+-----------------------------
+
+* `2013-11-08 <https://zenodo.org/record/1043886>`_

--- a/APE1.rst
+++ b/APE1.rst
@@ -155,7 +155,10 @@ already listed, the update champion can add themselves to the author list for
 the APE being updated. A new section, **Previous versions of this APE** should
 be added to the bottom of the APE (if not already there) with a bullet point
 list of dates which link to the DOI of the previous versions of APEs as well as
-links to the merge commits of the APEs.
+links to the merge commits of the APEs. The `date-last-revised` header for the APE
+should be updated, and a `revised-by` header should be added for each
+update (see the first `revised-by` section of *this* APE for a formatting 
+example).
 
 The review process is the same as for a newly-proposed APE as described in the
 **APE Review** section above.

--- a/APE1.rst
+++ b/APE1.rst
@@ -1,11 +1,11 @@
 APE Purpose and Process
 -----------------------
 
-author: Perry Greenfield
+author: Perry Greenfield, Lia Corrales
 
 date-created: 2013 October 11
 
-date-last-revised: 2013 November 8
+date-last-revised: 2020 July
 
 date-accepted: 2013 November 8
 
@@ -138,6 +138,28 @@ An APE's status can
   The goal is to try to reflect the overall community opinion in these
   rationales, so that new community members can understand why a decision was
   made.
+
+Modifications to an APE
+.......................
+
+**Addendum: July 2020**
+
+An APE can be modified, with one person acting as "champion" for the
+APE update. Similar to the APE development procedure, the update
+champion should discuss their desired changes with the astropy
+community (e.g., through the astropy-dev mailing list).
+
+Following a discussion on astropy-dev, the APE update shall be
+submitted as a Pull Request. The submission of the Pull Request should
+be announced formally on the astropy-dev list before they are
+accepted. If not already listed, the update champion can add
+themselves to the author list for the APE being updated. When
+appropriate, major changes to an APE document are encouraged to be
+clearly labeled as an addendum.
+
+The Astropy Coordinating Committee is responsible for reviewing and
+ultimately accepting Pull Requests for changes to individual APEs,
+unless otherwise specified within the APE document of interest.
 
 Branches and Pull requests
 --------------------------

--- a/APE1.rst
+++ b/APE1.rst
@@ -13,7 +13,7 @@ type: Process
 
 status: Accepted
 
-revised-by: Lia Corrales, Thomas Robitaille - 2021 February 26 - Added APE modification process
+revised-by: Lia Corrales, Thomas Robitaille, Erik Tollerud - 2021 February 26 - Added APE modification process
 
 Abstract
 --------


### PR DESCRIPTION
I have updated a section of APE1 to include procedures for updating APEs via pull request.

The procedure is much like the creation of APEs, in that one person is expected the "champion" the modification PR with feedback from astropy-dev and similar communication venues. This policy will be useful as we go forward with more formal governance structures, e.g., those outlined in the forthcoming APE-0.