### PR TITLE
APE 21: APE on ending long term support releases + Updates to APE 2 to reflect new release cycle without LTS

### DIFF
--- a/APE2.rst
+++ b/APE2.rst
@@ -85,8 +85,7 @@ additions are still acceptable.  The standard calendar for a release will be:
 
 This is not meant to be an exactly strict calendar, as the day of the week,
 existence of holidays, and degree of readiness of key features or critical bug
-fixes necessitate slop in the exact timing.  So more what you'd call guidelines
-than actual rules.
+fixes necessitate slop in the exact timing.
 
 Rapid Feature Releases
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -104,7 +103,7 @@ release, a v6.1.0 release could occur at that time.  Once that release has
 completed, the release clock is "reset", so v6.2.0 would be released six months
 after v6.1.0, even though it is not yet 12 months after v6.0.0. The next two
 releases would then be v6.3.0 and v6.4.0, because v6.4.0 would only be 21 months after
-v6.0.0. v7.0 would then either come three months or six months later, depending on
+v6.0.0. v7.0.0 would then either come three months or six months later, depending on
 how much work is planned to be new in v7.0.0.
 
 Releases and backwards compatibility

--- a/APE2.rst
+++ b/APE2.rst
@@ -21,9 +21,9 @@ Abstract
 
 This APE describes the general plan for timing of releases of the core package
 and their version numbers. The basic premise follows the terminology of semantic
-versioning: *major* releases (e.g., 6.0.0) every two years, *minor* releases (e.g.,
-6.1.0) every six months in between, and *bugfix* releases (e.g., 6.1.2) as
-needed within the six months between minor releases.
+versioning: *major* releases (e.g., 6.0.0) every year (or longer), *minor*
+releases (e.g., 6.1.0) typically every six months in between, and *bugfix*
+releases (e.g., 6.1.2) as needed between minor releases.
 
 Detailed description
 --------------------
@@ -48,10 +48,11 @@ Release versioning and scheduling
 
 The release cycle for the core package should be as follows:
 
-* Major releases every two years. These are releases that can introduce breaking
+* Major releases every year (or longer). These are releases that can introduce breaking
   API changes, and should be numbered as x.0.0 (e.g., 6.0.0).
-* Minor releases every six months in between. These releases should minimize any
-  API changes and focus on adding new features.
+* Minor releases by default every six months in between major releases (or more
+  frequent if needed). These releases should minimize any API changes and focus
+  on adding new features.
 * Bugfix releases as needed between minor releases.
 
 As an example, starting from the 6.0.0 release, the version number schedule might be:
@@ -62,13 +63,29 @@ As an example, starting from the 6.0.0 release, the version number schedule migh
 * 6.1.0 (six months after 6.0.0)
 * 6.1.1
 * 6.1.2
+* 7.0.0 (six months after 6.1.0, one year after 6.0.0)
+
+In the above scenario, we would adopt the default 6-month release schedule, and
+introduce a new major version with breaking changes one year later. However, the
+release schedule could also look like the following:
+
+* 6.0.0
+* 6.0.1
+* 6.0.2
+* 6.1.0 (three months after 6.0.0)
+* 6.1.1
+* 6.1.2
 * 6.2.0 (six months after 6.1.0)
 * 6.2.1
-* 6.3.0 (six months after 6.2.0)
+* 6.3.0 (four months after 6.2.0)
 * 6.3.1
 * 6.3.2
 * 6.3.3
-* 7.0.0 (six months after 6.3.0, two years after 6.0.0)
+* 7.0.0 (five months after 6.3.0, 18 months after 6.0.0)
+
+In the above hypothetical scenario, the developers have decided to release minor
+releases more frequently than every six months, and a year after 6.0.0 there was
+no need for a major version, so this was delayed until 18 months after 6.0.0.
 
 Feature freeze/testing calendar
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -94,17 +111,16 @@ This plan is not meant to exclude the possibility of minor releases *more* frequ
 than every six months.  Six months should be considered both the maximum and the
 default timeline, but a *shorter* time between releases is allowable, if the
 community agrees it is worthwhile. When/if this happens, the subsequent major
-release should be timed such that is at least two years after the last major release, even
-though that may mean there are more than 3 releases between the major releases.
+release should be timed such that is at least one year after the last major release, even
+though that may mean there are more than one minor release between the major releases.
 
 For example, if a new feature is perceived by the Astropy developer community as
 being of great importance, and is completed only three months after the v6.0.0
 release, a v6.1.0 release could occur at that time.  Once that release has
 completed, the release clock is "reset", so v6.2.0 would be released six months
-after v6.1.0, even though it is not yet 12 months after v6.0.0. The next two
-releases would then be v6.3.0 and v6.4.0, because v6.4.0 would only be 21 months after
-v6.0.0. v7.0.0 would then either come three months or six months later, depending on
-how much work is planned to be new in v7.0.0.
+after v6.1.0, even though it is not yet 12 months after v6.0.0. The next release
+could then be v7.0.0 three or more months after v6.2.0, or could also be another
+minor release.
 
 Releases and backwards compatibility
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,13 +130,11 @@ The guidelines in relation to API changes and backward compatibility are as foll
 * API changes (i.e., modifications as opposed to additions) should only be
   carried out in major releases.
 * Any API changes should be preceded by deprecation warnings that should be
-  visible to users in at least one minor release cycle prior to the API change
+  visible to users for at least a year prior to the API change
   being carried out.
 * API changes should be documented, with clear guidance on what is changing,
   why the change is being made, and how to migrate existing code to the new behavior.
-* New deprecations should not be introduced in bugfix releases - this will
-  ensure that deprecations will therefore be emitted for at least 6 months
-  before a major release.
+* New deprecations should not be introduced in bugfix releases.
 * If developers wish to make an API change at a point in time where the next
   release is a major release, they should introduce the deprecation in the major
   release and carry out the change in the following major release.

--- a/APE2.rst
+++ b/APE2.rst
@@ -20,7 +20,7 @@ Abstract
 --------
 
 This APE describes the general plan for timing of releases of the core package
-and their version numbers. The basic premise follows the terminology of semantic
+and their version numbers. The basic premise follows semantic
 versioning: *major* releases (e.g., 6.0.0) every year (or longer), *minor*
 releases (e.g., 6.1.0) typically every six months in between, and *bugfix*
 releases (e.g., 6.1.2) as needed between minor releases.

--- a/APE2.rst
+++ b/APE2.rst
@@ -5,7 +5,7 @@ author: Erik Tollerud
 
 date-created: 2013 November 18
 
-date-last-revised: 2013 December 11
+date-last-revised: 2023 April 27
 
 date-accepted: 2013 December 10
 
@@ -13,74 +13,62 @@ type: Process
 
 status: Accepted
 
+revised-by: Thomas Robitaille, Pey Lian Lim, Simon Conseil - 2023 April 27 - Rewritten following the approval of APE 21 to no longer have Long Term Support (LTS) versions
+
 
 Abstract
 --------
 
-This APE describes the general plan for timing of releases and their version
-numbers.  The basic premise is a 6-month cycle for new feature releases, with
-releases designated "long-term support" (LTS) releases every two years.  Bugfix
-releases occur as needed, on both the current feature release and the LTS
-releases.
-
+This APE describes the general plan for timing of releases of the core package
+and their version numbers. The basic premise follows the terminology of semantic
+versioning: *major* releases (e.g. 6.0.0) every two years, *minor* releases (e.g.
+6.1.0) every six months in between, and *bugfix* releases (e.g. 6.1.2) as
+needed within the six months between minor releases.
 
 Detailed description
 --------------------
 
-The release plan through version 0.3 has been somewhat haphazard, with releases
-when a certain set of features are judged "ready", but without a clear sense of
-how long those features will take.  This has lead to concerns that new features
-are spending a long time in the development version because *other* features are
-not yet complete.  At the same time, some larger institutions and facilities
-have expressed concern that there is not a clearly-stated support cycle for
-Astropy versions.  That is, it is not clear if a given version will be supported
-via critical bug fixes if it is not the latest version.  This was voiced as a
+The release plan prior to v0.3 was somewhat haphazard, with releases carried out when a
+certain set of features were judged "ready", but without a clear sense of how
+long those features would take.  This led to concerns that new features were
+spending a long time in the development version because *other* features were
+not yet complete.  At the same time, some larger institutions and facilities had
+back then expressed concern that there was not a clearly-stated support cycle for
+Astropy versions. That is, it was not clear if a given version would be supported
+via critical bug fixes if it was not the latest version.  This was voiced as a
 concern because facilities will not always want to upgrade to the latest
-version, but do want to be sure major bugs will get addressed.
+version, but do want to be sure major bugs will get addressed. This led to the
+initial version of this APE following discussions at the 2013 Coordination
+Meeting. This APE is a living document and is meant to reflect the latest
+release guidelines (prior versions can be found in `Previous versions of this
+APE`_).
 
-Release scheduling and LTS
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Release versioning and scheduling
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-These issues were discussed in the 2013 Coordination Meeting, and the following
-proposal represents a consensus from that meeting on the solution, with some
-modifications based on community feedback after the meeting.  Starting with
-version 0.4 , Astropy will have a feature release at least as often as every six
-months.  Releases between feature releases will only contain bugfixes, not new
-features. (See the "Releases and backwards compatibility" section below for more
-on what is considered a bug fix).
+The release cycle for the core package should be as follows:
 
-Additionally, some feature releases will be designated "long-term support" (LTS)
-releases, and these will continue to receive bugfixes for at least two years
-(i.e., typically 3 regular feature releases will follow an LTS release).  This
-addresses the first issue by applying a time-based release cycle, meaning no
-feature will need to wait more than six months before reaching users.
-Simultaneously, it addresses the second concern by providing a guarantee to
-facilities that if they use an LTS, they can count on releases fixing critical
-bugs for at least two years.  Finally, the LTS releases also act as a convenient
-time to submit new Astropy journal papers.
+* Major releases every two years. These are releases that can introduce breaking
+  API changes, and should be numbered as x.0.0 (e.g. 6.0.0).
+* Minor releases every six months in between. These releases should minimize any
+  API changes and focus on adding new features.
+* Bugfix releases as needed between minor releases.
 
-Version numbering
-^^^^^^^^^^^^^^^^^
+As an example, starting from the 6.0.0 release, the version number schedule might be:
 
-To match this release plan, Astropy will adopt a version numbering scheme of the
-form ``x.y.z``, where ``z`` is advanced on a bugfix release, ``y`` is advanced
-for a feature release that is *not* an LTS release, and ``x`` is advanced on an
-LTS (which also resets ``y`` to 0).  So starting from the first LTS release, the
-version number schedule might be::
-
-* 1.0.0 (LTS release)
-* 1.0.1
-* 1.0.2
-* 1.1.0 (six months after 1.0.0)
-* 1.1.1
-* 1.0.3
-* 1.1.2
-* 1.2.0 (six months after 1.1.0)
-* 1.2.1
-* 1.3.0 (six months after 1.2.0)
-* 1.0.4
-* 1.3.1
-* 2.0.0 (LTS release, six months after 1.3.0)
+* 6.0.0
+* 6.0.1
+* 6.0.2
+* 6.1.0 (six months after 6.0.0)
+* 6.1.1
+* 6.1.2
+* 6.2.0 (six months after 6.1.0)
+* 6.2.1
+* 6.3.0 (six months after 6.2.0)
+* 6.3.1
+* 6.3.2
+* 6.3.3
+* 7.0.0 (six months after 6.3.0, two years after 6.0.0)
 
 Feature freeze/testing calendar
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -103,42 +91,92 @@ than actual rules.
 Rapid Feature Releases
 ^^^^^^^^^^^^^^^^^^^^^^
 
-This plan is not meant to exclude the possibility of releases *more* frequent
+This plan is not meant to exclude the possibility of minor releases *more* frequent
 than every six months.  Six months should be considered both the maximum and the
 default timeline, but a *shorter* time between releases is allowable, if the
-community agrees it is worthwhile. When/if this happens, the subsequent LTS
-release should be timed such that is at least two years after the last LTS, even
-though that may mean there are more than 3 releases between the LTSs.
+community agrees it is worthwhile. When/if this happens, the subsequent major
+release should be timed such that is at least two years after the last major release, even
+though that may mean there are more than 3 releases between the major releases.
 
 For example, if a new feature is perceived by the Astropy developer community as
-being of great importance, and is completed only three months after the v1.0
-release, a v1.1 release could occur at that time.  Once that release has
-completed, the release clock is "reset", so v1.2 would be released six months
-after v1.1, even though it is not yet 12 months after v1.0. The next two
-releases would then be v1.3 and v1.4, because v1.4 would only be 21 months after
-v1.0. v2.0 would then either come three months or six months later, depending on
-how much work is planned to be new in v2.0.
+being of great importance, and is completed only three months after the v6.0.0
+release, a v6.1.0 release could occur at that time.  Once that release has
+completed, the release clock is "reset", so v6.2.0 would be released six months
+after v6.1.0, even though it is not yet 12 months after v6.0.0. The next two
+releases would then be v6.3.0 and v6.4.0, because v6.4.0 would only be 21 months after
+v6.0.0. v7.0 would then either come three months or six months later, depending on
+how much work is planned to be new in v7.0.0.
 
 Releases and backwards compatibility
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-As defined here, a "bugfix release" must not break backwards compatibility as
-defined by the public API, and it also should not introduce new major features.
-The exception to this is cases where the API has an actual mistake that needs to
-be fixed, such as a function argument that is missing but was clearly intended
-to be there. Further, a bugfix release *can* include documentation improvements,
-and in the future there may be some sort of "sandbox" package to act as a
-preview or testbed for new additions to come in the next feature release.
+The guidelines in relation to API changes and backward compatibility are as follows:
 
-Feature releases do *not* guarantee backwards compatibility with previous
-releases.  However, all backwards incompatible changes should always be
-mentioned in the release notes for a new version.  Furthermore, when possible, a
-backwards incompatible change should generate an `AstropyDeprecationWarning` for
-at least one feature release version before actually making the change
-permanent, to allow codes to transition to the new interface. A future APE may
-add to or change this with a more concrete policy on when and for how long
-something should be deprecated.
+* API changes (i.e., modifications as opposed to additions) should only be carried out in major releases.
+* Any API changes should be preceded by deprecation warnings that should be
+  visible to users in at least one minor release cycle prior to the API change
+  being carried out.
+* New deprecations should not be introduced in bugfix releases - this will
+  ensure that deprecations will therefore be emitted for at least 6 months
+  before a major release.
+* If developers wish to make an API change at a point in time where the next
+  release is a major release, they should introduce the deprecation in the major
+  release and carry out the change in the following major release.
+* The following will not be considered to be part of the API and can therefore
+  be changed in bugfix and minor releases:
 
+    * Changes to warning messages
+    * Changes to exception messages
+    * Changes to the ``__repr__`` or ``__repr_*__`` of objects
+
+  However, exception and warning *types* will be considered to be part of the
+  API.
+
+As with all guidelines, there are exceptions where we can deviate from these guidelines:
+
+* API changes can be carried out in major releases without deprecation if it is
+  not possible to have a deprecation phase due to the nature of the change.
+* Changes breaking or changing the behavior of code may be needed in order to
+  fix bugs. Such changes can be made in bugfix or minor releases and do not need
+  to be considered API changes.
+* Changes to exception or warning types may occasionally be done in minor
+  releases.
+
+These exceptions will require judgment calls on the part of maintainers, but any
+such changes should be minimized as much as possible and clearly communicated to
+users (see `Communication with users`_).
+
+Documentation and performance improvements can be made in bugfix releases as long
+as they do not involve any changes or additions to the API.
+
+Communication with users
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is imperative that we communicate effectively with users so that they understand
+what to expect from different releases:
+
+* We should include documentation for the core package that describes the
+  release policy above, namely that in general minor releases will not
+  break/remove functionality, but that major releases might, and also explaining
+  what is considered API.
+
+* We should ensure that any changes in releases which deviate from the
+  guidelines above are clearly communicated to users - for example any API/breaking
+  changes in minor releases should be included in the "What's New" page for the
+  minor release.
+
+* Deprecations should always be mentioned in the changelog, as well as any
+  removal of deprecated code/API changes. We do not specify how exactly this
+  should be done, but note that e.g. Numpy release notes have separate sections
+  entitled *Deprecations*, *Expired Deprecations* and *Compatibility Notes* in
+  their release notes (see `here
+  <https://numpy.org/doc/stable/release/1.24.0-notes.html>`_ for an example)
+  which is clearer than having a single *API changes* section.
+
+* Maintainers should be encouraged to advertise pull requests with API changes
+  that are likely to affect users and developers of other packages to the
+  developer mailing list, and ensuring that the pull request has adequate time
+  (at least two weeks) to be reviewed properly.
 
 Branches and pull requests
 --------------------------
@@ -149,22 +187,8 @@ N/A
 Implementation
 --------------
 
-If this APE is accepted, a few organizational steps will be required:
-
-* The currently under-development version "v0.4" will be the first following
-  the release cycle.  Because v0.3 was released On the last Monday in Nov 2013,
-  the feature freeze and beta for v0.4 will be scheduled for the last Monday in
-  April 2014, With a release at the end of May 2014.  The milestone on GitHub
-  will thus need to be updated to match this.
-* The first LTS release (v1.0) will then come six months after v0.4, so an
-  appropriate milestone will need to be added to GitHub.  Following that,
-  milestones should be added as needed to reflect the versioning scheme
-  described in this APE.
-* The documentation should be updated to mention the existence of LTS releases
-  and make it clear that they come with a promise of two years of bug fixes (as
-  needed). It should also add a link to this APE so that those interested in the
-  numbering scheme can look here for details.
-
+Whenever this APE is updated, the core package documentation should be updated
+to reflect the latest guidelines described above.
 
 Backward compatibility
 ----------------------
@@ -175,20 +199,7 @@ N/A
 Alternatives
 ------------
 
-An alternative version numbering scheme mentioned on astropy-dev was to continue
-the current scheme of ``0.x.y``, and simply append `-LTS` for LTS releases. The
-disadvantage of this approach is that the first version number is then rendered
-essentially meaningless.  That is, given its nature as a research library, it is
-unlikely to ever be "feature-complete", and hence there is no clear break point
-for a 1.0 version.  The scheme proposed here simply assigns a different meaning
-to the major version as "number of LTSs since the start of the project".
-
-Another alternative is to use `semantic versioning <http://semver.org/>`_. The
-disadvantage of that approach for Astropy is that it is very likely that *all*
-versions in the foreseeable future will break backwards compatibility to some
-extent.  In semantic versioning, this would mean all versions would need to be
-of the form ``x.0.y``, rendering the minor version number meaningless.
-
+N/A
 
 Decision rationale
 ------------------
@@ -200,3 +211,8 @@ original proposal was the addition of the idea that *less than* six month
 releases were acceptable. The above content reflects those suggestions, and the
 APE was accepted 12/10/13, as there were no significant objections from the
 community.
+
+Previous versions of this APE
+-----------------------------
+
+* 2013-12-10 [`DOI <https://doi.org/10.5281/zenodo.1043887>`_] [`GitHub <https://github.com/astropy/astropy-APEs/blob/48f949c05efa4f07ed8915eccdb0cd139c57b6f6/APE2.rst>`_]

--- a/APE2.rst
+++ b/APE2.rst
@@ -5,7 +5,7 @@ author: Erik Tollerud
 
 date-created: 2013 November 18
 
-date-last-revised: 2023 April 27
+date-last-revised: 2023 May 15
 
 date-accepted: 2013 December 10
 
@@ -13,7 +13,7 @@ type: Process
 
 status: Accepted
 
-revised-by: Thomas Robitaille, Pey Lian Lim, Simon Conseil - 2023 April 27 - Rewritten following the approval of APE 21 to no longer have Long Term Support (LTS) versions
+revised-by: Thomas Robitaille, Pey Lian Lim, Simon Conseil - 2023 May 15 - Rewritten following the approval of APE 21 to no longer have Long Term Support (LTS) versions
 
 
 Abstract

--- a/APE2.rst
+++ b/APE2.rst
@@ -5,7 +5,7 @@ author: Erik Tollerud
 
 date-created: 2013 November 18
 
-date-last-revised: 2023 May 15
+date-last-revised: 2023 May 31
 
 date-accepted: 2013 December 10
 

--- a/APE2.rst
+++ b/APE2.rst
@@ -125,9 +125,9 @@ The guidelines in relation to API changes and backward compatibility are as foll
 * The following will not be considered to be part of the API and can therefore
   be changed in bugfix and minor releases:
 
-    * Changes to warning messages
-    * Changes to exception messages
-    * Changes to the ``__repr__`` or ``__repr_*__`` of objects
+  * Changes to warning messages
+  * Changes to exception messages
+  * Changes to the ``__repr__`` or ``__repr_*__`` of objects
 
   However, exception and warning *types* will be considered to be part of the
   API.

--- a/APE2.rst
+++ b/APE2.rst
@@ -21,8 +21,8 @@ Abstract
 
 This APE describes the general plan for timing of releases of the core package
 and their version numbers. The basic premise follows the terminology of semantic
-versioning: *major* releases (e.g. 6.0.0) every two years, *minor* releases (e.g.
-6.1.0) every six months in between, and *bugfix* releases (e.g. 6.1.2) as
+versioning: *major* releases (e.g., 6.0.0) every two years, *minor* releases (e.g.,
+6.1.0) every six months in between, and *bugfix* releases (e.g., 6.1.2) as
 needed within the six months between minor releases.
 
 Detailed description
@@ -49,7 +49,7 @@ Release versioning and scheduling
 The release cycle for the core package should be as follows:
 
 * Major releases every two years. These are releases that can introduce breaking
-  API changes, and should be numbered as x.0.0 (e.g. 6.0.0).
+  API changes, and should be numbered as x.0.0 (e.g., 6.0.0).
 * Minor releases every six months in between. These releases should minimize any
   API changes and focus on adding new features.
 * Bugfix releases as needed between minor releases.
@@ -167,7 +167,7 @@ what to expect from different releases:
 
 * Deprecations should always be mentioned in the changelog, as well as any
   removal of deprecated code/API changes. We do not specify how exactly this
-  should be done, but note that e.g. Numpy release notes have separate sections
+  should be done, but note that, e.g., Numpy release notes have separate sections
   entitled *Deprecations*, *Expired Deprecations* and *Compatibility Notes* in
   their release notes (see `here
   <https://numpy.org/doc/stable/release/1.24.0-notes.html>`_ for an example)

--- a/APE2.rst
+++ b/APE2.rst
@@ -112,10 +112,13 @@ Releases and backwards compatibility
 
 The guidelines in relation to API changes and backward compatibility are as follows:
 
-* API changes (i.e., modifications as opposed to additions) should only be carried out in major releases.
+* API changes (i.e., modifications as opposed to additions) should only be
+  carried out in major releases.
 * Any API changes should be preceded by deprecation warnings that should be
   visible to users in at least one minor release cycle prior to the API change
   being carried out.
+* API changes should be documented, with clear guidance on what is changing,
+  why the change is being made, and how to migrate existing code to the new behavior.
 * New deprecations should not be introduced in bugfix releases - this will
   ensure that deprecations will therefore be emitted for at least 6 months
   before a major release.

--- a/APE2.rst
+++ b/APE2.rst
@@ -188,7 +188,7 @@ Implementation
 --------------
 
 Whenever this APE is updated, the core package documentation should be updated
-to reflect the latest guidelines described above.
+to reflect the latest guidelines described above: https://github.com/astropy/astropy/pull/14713
 
 Backward compatibility
 ----------------------

--- a/APE21.rst
+++ b/APE21.rst
@@ -27,12 +27,13 @@ Detailed description
 Motivation
 ^^^^^^^^^^
 
-`APE 2: Astropy Release Cycle and Version Numbering <https://doi.org/10.5281/zenodo.1043887>`_ describes the release cycle
-for the core astropy package, which consists of major releases every 6 months that
-add new features (e.g., v5.2), and releases in between this that are limited to fixing bugs
-or updating documentation (e.g., v5.2.1). Every 2 years, major releases are designated
-as being LTS (e.g., v5.0) and we have committed to releasing bugfix releases
-for this version (e.g., v5.0.3) for up to 2 years.
+The original `APE 2: Astropy Release Cycle and Version Numbering <https://doi.org/10.5281/zenodo.1043887>`_
+describes the release cycle for the core astropy package, which consists of
+major releases every 6 months that add new features (e.g., v5.2), and releases
+in between this that are limited to fixing bugs or updating documentation (e.g.,
+v5.2.1). Every 2 years, major releases are designated as being LTS (e.g., v5.0)
+and we have committed to releasing bugfix releases for this version (e.g.,
+v5.0.3) for up to 2 years.
 
 At the start of the project, having LTS releases was critical for acceptance by
 large organizations/projects for which stability is paramount, as the core package went through
@@ -87,70 +88,8 @@ backported.
 Guidelines on deprecations and API changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The main proposed guidelines are as follows:
-
-* API changes should only be carried out in major releases.
-* Any API changes should be preceded by deprecation warnings that should be
-  visible to users in at least one minor release cycle prior to the API change
-  being carried out.
-* New deprecations should not be introduced in bugfix releases - this will
-  ensure that deprecations will therefore be emitted for at least 6 months
-  before a major release.
-* If developers wish to make an API change at a point in time where the next
-  release is a major release, they should introduce the deprecation in the major
-  release and carry out the change in the following major release.
-* The following will not be considered to be part of the API and can therefore
-  be changed in bugfix and minor releases:
-
-    * Changes to warning messages
-    * Changes to exception messages
-    * Changes to the ``__repr__`` or ``__repr_*__`` of objects
-
-  However, exception and warning *types* will be considered to be part of the
-  API.
-
-As with all guidelines, there are exceptions where we can deviate from these guidelines:
-
-* API changes can be carried out in major releases without deprecation if it is
-  not possible to have a deprecation phase due to the nature of the change.
-* Changes breaking or changing the behavior of code may be needed in order to
-  fix bugs. Such changes can be made in bugfix or minor releases and do not need
-  to be considered API changes.
-* Changes to exception or warning types may occasionally be done in minor
-  releases.
-
-These exceptions will require judgment calls on the part of maintainers, but any
-such changes should be minimized as much as possible and clearly communicated to
-users (see `Communication with users`_).
-
-Communication with users
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-It is imperative that we communicate effectively with users so that they understand
-what to expect from different releases:
-
-* We should include documentation for the core package that describes the
-  release policy above, namely that in general minor releases will not
-  break/remove functionality, but that major releases might, and also explaining
-  what is considered API.
-
-* We should ensure that any changes in releases which deviate from the
-  guidelines above are clearly communicated to users - for example any API/breaking
-  changes in minor releases should be included in the "What's New" page for the
-  minor release.
-
-* Deprecations should always be mentioned in the changelog, as well as any
-  removal of deprecated code/API changes. We do not specify how exactly this
-  should be done, but note that e.g. Numpy release notes have separate sections
-  entitled *Deprecations*, *Expired Deprecations* and *Compatibility Notes* in
-  their release notes (see `here
-  <https://numpy.org/doc/stable/release/1.24.0-notes.html>`_ for an example)
-  which is clearer than having a single *API changes* section.
-
-* Maintainers should be encouraged to advertise pull requests with API changes
-  that are likely to affect users and developers of other packages to the
-  developer mailing list, and ensuring that the pull request has adequate time
-  (at least two weeks) to be reviewed properly.
+To avoid duplication, guidelines on deprecations and API changes as well as
+recommendations for communication with users will be added directly to APE 2.
 
 Branches and pull requests
 --------------------------
@@ -161,13 +100,12 @@ Implementation
 --------------
 
 This APE proposes to continue supporting the v5.0.x LTS series but to not
-designate v6.0 as LTS.
+designate v6.0.0 as LTS.
+
+Changes to APE 2 can be reviewed in https://github.com/astropy/astropy-APEs/pull/84
 
 After acceptance of this APE, the documentation for the core package should be
-updated appropriately as described in `Communication with users`_, and `APE 2:
-Astropy Release Cycle and Version Numbering
-<https://doi.org/10.5281/zenodo.1043887>`_ should be updated to point to this
-APE as superseding it in terms of LTS releases.
+updated appropriately.
 
 Backward compatibility
 ----------------------

--- a/APE21.rst
+++ b/APE21.rst
@@ -7,11 +7,11 @@ date-created: 2023 February 16
 
 date-last-revised: 2023 May 15
 
-date-accepted: <replace with accepted date>
+date-accepted: 2023 May 31
 
 type: Process
 
-status: Discussion
+status: accepted
 
 
 Abstract
@@ -139,6 +139,8 @@ packages in the scientific Python ecosystem.
 Decision rationale
 ------------------
 
-<To be filled in by the coordinating committee when the APE is accepted or rejected>
+There is broad consensus in the community that the old model of LTE releases is no longer required, given the
+stability that the astropy core package has reached. On the other hand, the maintenance burden described in this APE binds significant resources that are needed in other parts of the project. Thus, this APE is accepted
+to simplify the workflow. 
 
 .. _APE 2: https://doi.org/10.5281/zenodo.1043887

--- a/APE21.rst
+++ b/APE21.rst
@@ -5,7 +5,7 @@ author: Thomas Robitaille, Pey Lian Lim, Simon Conseil
 
 date-created: 2023 February 16
 
-date-last-revised: 2023 February 21 <keep this up to date anytime something changes>
+date-last-revised: 2023 February 25
 
 date-accepted: <replace with accepted date>
 
@@ -54,7 +54,7 @@ LTS releases are however not without cost:
 
 In addition, it is not clear that LTS releases are needed anymore - now that the
 core package is over ten years old, it has reached a much higher level of
-stability. No other main package in the scientific Python ecosystem has LTS
+stability. Most packages in the scientific Python ecosystem do not have LTS
 releases, and there is no longer a strong argument for having this
 in astropy either.
 
@@ -96,9 +96,18 @@ The main proposed guidelines are as follows:
 * New deprecations should not be introduced in bugfix releases - this will
   ensure that deprecations will therefore be emitted for at least 6 months
   before a major release.
-* If developers wish to make an API change at a point in time where the next release
-  is a major release, they should introduce the deprecation in the major release
-  and carry out the change in the following major release.
+* If developers wish to make an API change at a point in time where the next
+  release is a major release, they should introduce the deprecation in the major
+  release and carry out the change in the following major release.
+* The following will not be considered to be part of the API and can therefore
+  be changed in bugfix and minor releases:
+
+    * Changes to warning messages
+    * Changes to exception messages
+    * Changes to the ``__repr__`` or ``__repr_*__`` of objects
+
+  However, exception and warning *types* will be considered to be part of the
+  API.
 
 As with all guidelines, there are exceptions where we can deviate from these guidelines:
 
@@ -107,8 +116,8 @@ As with all guidelines, there are exceptions where we can deviate from these gui
 * Changes breaking or changing the behavior of code may be needed in order to
   fix bugs. Such changes can be made in bugfix or minor releases and do not need
   to be considered API changes.
-* Changes to exception types or warning/error messages may occasionally be
-  needed in non-major releases.
+* Changes to exception or warning types may occasionally be done in minor
+  releases.
 
 These exceptions will require judgment calls on the part of maintainers, but any
 such changes should be minimized as much as possible and clearly communicated to
@@ -122,19 +131,21 @@ what to expect from different releases:
 
 * We should include documentation for the core package that describes the
   release policy above, namely that in general minor releases will not
-  break/remove functionality, but that major releases might.
+  break/remove functionality, but that major releases might, and also explaining
+  what is considered API.
 
 * We should ensure that any changes in releases which deviate from the
   guidelines above are clearly communicated to users - for example any API/breaking
   changes in minor releases should be included in the "What's New" page for the
   minor release.
 
-* Deprecations should always be mentioned in the changelog, as well as any removal
-  of deprecated code/API changes. We do not specify how exactly this should be done,
-  but note that e.g. Numpy have separate sections entitled *Deprecations*,
-  *Expired Deprecations* and *Compatibility Notes* in their release notes (see
-  `here <https://numpy.org/doc/stable/release/1.24.0-notes.html>`_ for an
-  example) which is clearer than having a single *API changes* section.
+* Deprecations should always be mentioned in the changelog, as well as any
+  removal of deprecated code/API changes. We do not specify how exactly this
+  should be done, but note that e.g. Numpy release notes have separate sections
+  entitled *Deprecations*, *Expired Deprecations* and *Compatibility Notes* in
+  their release notes (see `here
+  <https://numpy.org/doc/stable/release/1.24.0-notes.html>`_ for an example)
+  which is clearer than having a single *API changes* section.
 
 * Maintainers should be encouraged to advertise pull requests with API changes
   that are likely to affect users and developers of other packages to the
@@ -152,6 +163,12 @@ Implementation
 This APE proposes to continue supporting the v5.0.x LTS series but to not
 designate v6.0 as LTS.
 
+After acceptance of this APE, the documentation for the core package should be
+updated appropriately as described in `Communication with users`_, and `APE 2:
+Astropy Release Cycle and Version Numbering
+<https://doi.org/10.5281/zenodo.1043887>`_ should be updated to point to this
+APE as superseding it in terms of LTS releases.
+
 Backward compatibility
 ----------------------
 
@@ -161,7 +178,7 @@ Alternatives
 ------------
 
 We could keep the current release workflow - however as mentioned above this has
-a maintenance cost and it is not something that is done by any other major
+a maintenance cost and it is not something that is done by most other major
 packages in the scientific Python ecosystem.
 
 Decision rationale

--- a/APE21.rst
+++ b/APE21.rst
@@ -5,7 +5,7 @@ author: Thomas Robitaille, Pey Lian Lim, Simon Conseil
 
 date-created: 2023 February 16
 
-date-last-revised: 2023 April 27
+date-last-revised: 2023 May 15
 
 date-accepted: <replace with accepted date>
 

--- a/APE21.rst
+++ b/APE21.rst
@@ -24,6 +24,9 @@ This APE proposes to no longer designate any releases of the core package as bei
 Detailed description
 --------------------
 
+Motivation
+^^^^^^^^^^
+
 `APE 2: Astropy Release Cycle and Version Numbering <https://doi.org/10.5281/zenodo.1043887>`_ describes the release cycle
 for the core astropy package, which consists of major releases every 6 months that
 add new features (e.g., v5.2), and releases in between this that are limited to fixing bugs
@@ -37,7 +40,7 @@ significant API changes from version to version due to the youth of the project 
 releases were a way to shield against these changes, or at least reduce disruption to
 be every 2 years.
 
-LTS releases are however not free:
+LTS releases are however not without cost:
 
 * While we use infrastructure to automate backporting fixes to release branches,
   in practice the LTS branch diverges more and more from the main development
@@ -55,10 +58,15 @@ stability. No other main package in the scientific Python ecosystem has LTS
 releases, and there is no longer a strong argument for having this
 in astropy either.
 
+Proposed release procedure
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 This APE proposes the following:
 
 * No longer designate any releases as LTS.
-* Keep the 6-month release cycle and bump releases to x.0 every 2 years.
+* Keep the 6-month release cycle and bump releases to x.0 every 2 years (with
+  the possibility of allowing this to be more or less than 2 years if there is a
+  consensus amongst core package maintainers that this can be changed)
 * Refer to the x.0 releases every 2 years (e.g., v6.0) as "major"
   releases, other releases every 6 months (e.g., v6.1) as "minor", and bug fixing
   releases (e.g., v6.1.2) as "bugfix" releases.
@@ -77,37 +85,56 @@ a deprecation warning until the next LTS release as deprecations are not typical
 backported.
 
 Guidelines on deprecations and API changes
-------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The main guidelines are as follows:
+The main proposed guidelines are as follows:
 
 * API changes should only be carried out in major releases.
 * Any API changes should be preceded by deprecation warnings that should be
   visible to users in at least one minor release cycle prior to the API change
   being carried out.
 * New deprecations should not be introduced in bugfix releases - this will
-  ensure that deprecations will therefore be advertised for at least 6 months
+  ensure that deprecations will therefore be emitted for at least 6 months
   before a major release.
-* If developers wish to make an API change at the point where the next release
+* If developers wish to make an API change at a point in time where the next release
   is a major release, they should introduce the deprecation in the major release
   and carry out the change in the following major release.
 
-As with all guidelines, there will be exceptions:
+As with all guidelines, there are exceptions where we can deviate from these guidelines:
 
 * API changes can be carried out in major releases without deprecation if it is
-  not possible to have a deprecation phase.
+  not possible to have a deprecation phase due to the nature of the change.
 * Changes breaking or changing the behavior of code may be needed in order to
   fix bugs. Such changes can be made in bugfix or minor releases and do not need
   to be considered API changes.
 * Changes to exception types or warning/error messages may occasionally be
-  needed in non-major releases but these should be minimized as users may rely
-  on these and they may therefore be considered API
+  needed in non-major releases.
 
 These exceptions will require judgment calls on the part of maintainers, but any
-such changes should be clearly communicated to users (e.g., via the 'What's New' page).
+such changes should be minimized as much as possible and clearly communicated to
+users (see `Communication with users`_).
 
 Communication with users
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is imperative that we communicate effectively with users so that they understand
+what to expect from different releases:
+
+* We should include documentation for the core package that describes the
+  release policy above, namely that in general minor releases will not
+  break/remove functionality, but that major releases might.
+
+* We should ensure that any changes in releases which deviate from the
+  guidelines above are clearly communicated to users - for example any API/breaking
+  changes in minor releases should be included in the "What's New" page for the
+  minor release.
+
+* Deprecations should always be mentioned in the changelog, as well as any removal
+  of deprecated code/API changes. We do not specify how exactly this should be done,
+  but note that e.g. Numpy have separate sections entitled *Deprecations*,
+  *Expired Deprecations* and *Compatibility Notes* in their release notes (see
+  `here <https://numpy.org/doc/stable/release/1.24.0-notes.html>`_ for an
+  example) which is clearer than having a single *API changes* section.
 
 Branches and pull requests
 --------------------------
@@ -128,7 +155,9 @@ N/A
 Alternatives
 ------------
 
-N/A
+We could keep the current release workflow - however as mentioned above this has
+a maintenance cost and it is not something that is done by any other major
+packages in the scientific Python ecosystem.
 
 Decision rationale
 ------------------

--- a/APE21.rst
+++ b/APE21.rst
@@ -31,15 +31,15 @@ Motivation
 The original `APE 2: Astropy Release Cycle and Version Numbering
 <https://doi.org/10.5281/zenodo.1043887>`_ describes the release cycle for the
 core astropy package, which consists of major releases every 6 months that add
-new features (e.g., v5.2), and releases in between this that are limited to
+new features (e.g., v5.2), and releases in between these that are limited to
 fixing bugs or updating documentation (e.g., v5.2.1). Every 2 years, major
 releases are designated as being LTS (e.g., v5.0) and we have committed to
-releasing bugfix releases for this version (e.g., v5.0.3) for up to 2 years.
+having bugfix releases for this version (e.g., v5.0.3) for up to 2 years.
 
 At the start of the project, having LTS releases was critical for acceptance by
 large organizations/projects for which stability is paramount, as the core
-package went through significant API changes from version to version due to the
-youth of the project and LTS releases were a way to shield against these
+package went through significant API changes between versions due to the
+youth of the project and LTS releases were a way to shield against such
 changes, or at least reduce disruption to be every 2 years.
 
 LTS releases are however not without cost:
@@ -47,11 +47,11 @@ LTS releases are however not without cost:
 * While we use infrastructure to automate backporting fixes to release branches,
   in practice the LTS branch diverges more and more from the main development
   branch and automated backports are more likely to fail as time goes on,
-  requiring human effort to manually do the backports, which can sometimes be
+  requiring human effort to manually perform the backports, which can sometimes be
   non-trivial.
 * Even once fixes are backported to the LTS branch, carrying out releases is not
   fully automated and requires manual steps, so having to do bugfix releases for
-  both the latest release branch and LTS branch puts an extra burden on the core
+  both the latest release branch and LTS branch puts an additional burden on the core
   package release team.
 
 In addition, it is not clear that LTS releases are needed anymore - now that the

--- a/APE21.rst
+++ b/APE21.rst
@@ -136,6 +136,11 @@ what to expect from different releases:
   `here <https://numpy.org/doc/stable/release/1.24.0-notes.html>`_ for an
   example) which is clearer than having a single *API changes* section.
 
+* Maintainers should be encouraged to advertise pull requests with API changes
+  that are likely to affect users and developers of other packages to the
+  developer mailing list, and ensuring that the pull request has adequate time
+  (at least two weeks) to be reviewed properly.
+
 Branches and pull requests
 --------------------------
 

--- a/APE21.rst
+++ b/APE21.rst
@@ -102,7 +102,7 @@ Implementation
 This APE proposes to continue supporting the v5.0.x LTS series but to not
 designate v6.0.0 as LTS.
 
-Changes to APE 2 can be reviewed in https://github.com/astropy/astropy-APEs/pull/84
+Changes to APE 2 can be reviewed in https://github.com/astropy/astropy-APEs/pull/82
 
 After acceptance of this APE, the documentation for the core package should be
 updated appropriately.

--- a/APE21.rst
+++ b/APE21.rst
@@ -5,7 +5,7 @@ author: Thomas Robitaille, Pey Lian Lim, Simon Conseil
 
 date-created: 2023 February 16
 
-date-last-revised: 2023 February 25
+date-last-revised: 2023 April 27
 
 date-accepted: <replace with accepted date>
 

--- a/APE21.rst
+++ b/APE21.rst
@@ -97,6 +97,11 @@ changes. This is in contrast to the current LTS system where users might not see
 a deprecation warning until the next LTS release as deprecations are not typically
 backported.
 
+As astropy becomes increasingly mature and stable, and since as described above
+the 1-year timescale between major releases is a minimum, the interval between
+major releases may become arbitrarily longer, and the package may reach a stage
+when the major version is no longer or very rarely increased.
+
 Guidelines on deprecations and API changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -106,7 +111,7 @@ recommendations for communication with users will be added directly to `APE 2`_.
 Branches and pull requests
 --------------------------
 
-N/A
+Updates to the core package documentation: https://github.com/astropy/astropy/pull/14713
 
 Implementation
 --------------

--- a/APE21.rst
+++ b/APE21.rst
@@ -5,7 +5,7 @@ author: Thomas Robitaille, Pey Lian Lim, Simon Conseil
 
 date-created: 2023 February 16
 
-date-last-revised: 2023 February 20 <keep this up to date anytime something changes>
+date-last-revised: 2023 February 21 <keep this up to date anytime something changes>
 
 date-accepted: <replace with accepted date>
 
@@ -18,7 +18,7 @@ Abstract
 --------
 
 This APE proposes to no longer designate any releases of the core package as being
-'long term support' (LTS) and provide guidance on how to handle API changes and deprecations.
+"long-term support" (LTS) and provide guidance on how to handle API changes and deprecations.
 
 
 Detailed description
@@ -27,15 +27,15 @@ Detailed description
 `APE 2: Astropy Release Cycle and Version Numbering <https://doi.org/10.5281/zenodo.1043887>`_ describes the release cycle
 for the core astropy package, which consists of major releases every 6 months that
 add new features (e.g., v5.2), and releases in between this that are limited to fixing bugs
-or updating documentation (e.g., v5.2.1). Every two years, major releases are designated
+or updating documentation (e.g., v5.2.1). Every 2 years, major releases are designated
 as being LTS (e.g., v5.0) and we have committed to releasing bugfix releases
-for this version (e.g., v5.0.3) for up to two years.
+for this version (e.g., v5.0.3) for up to 2 years.
 
 At the start of the project, having LTS releases was critical for acceptance by
 large organizations/projects for which stability is paramount, as the core package went through
 significant API changes from version to version due to the youth of the project and LTS
 releases were a way to shield against these changes, or at least reduce disruption to
-be every two years.
+be every 2 years.
 
 LTS releases are however not free:
 
@@ -58,10 +58,10 @@ in astropy either.
 This APE proposes the following:
 
 * No longer designate any releases as LTS.
-* Keep the 6-month release cycle and bump releases to x.0 every two years.
-* Refer to the x.0 releases every two years (e.g., v6.0) as 'major'
-  releases, other releases every 6 months (e.g., v6.1) as 'minor', and bug fixing
-  releases (e.g., v6.1.2) as 'bugfix releases'.
+* Keep the 6-month release cycle and bump releases to x.0 every 2 years.
+* Refer to the x.0 releases every 2 years (e.g., v6.0) as "major"
+  releases, other releases every 6 months (e.g., v6.1) as "minor", and bug fixing
+  releases (e.g., v6.1.2) as "bugfix" releases.
 * Minimize as much as possible any changes that break API or change results in
   minor releases, but being pragmatic and accepting such changes if they would
   not affect many users.
@@ -71,7 +71,7 @@ This APE proposes the following:
   are deemed to be high impact enough to wait longer).
 
 With this in place, we would effectively be striving to maximize stability over
-two year periods but users would see deprecation warnings to prepare them for
+two-year periods but users would see deprecation warnings to prepare them for
 changes. This is in contrast to the current LTS system where users might not see
 a deprecation warning until the next LTS release as deprecations are not typically
 backported.
@@ -91,9 +91,11 @@ Backward compatibility
 ----------------------
 
 N/A
+
 Alternatives
 ------------
 
+<Remove placeholder below before merge>
 If there were any alternative solutions to solving the same problem, they should
 be discussed here, along with a justification for the chosen approach.
 

--- a/APE21.rst
+++ b/APE21.rst
@@ -66,25 +66,33 @@ Proposed release procedure
 This APE proposes the following:
 
 * No longer designate any releases as LTS.
-* Keep the 6-month release cycle and bump releases to x.0.0 every 2 years (with
-  the possibility of allowing this to be more or less than 2 years if there is a
-  consensus amongst core package maintainers that this can be changed)
-* Refer to the x.0.0 releases every 2 years (e.g., v6.0.0) as "major"
-  releases, other releases every 6 months (e.g., v6.1.0) as "minor", and bug fixing
-  releases (e.g., v6.1.2) as "bugfix" releases.
-* Use the x.x.0 format for the first major/minor release in a cycle, rather than the
-  x.x format previously used, as this is more standard practice in particular since
-  we will be essentially doing semantic versioning.
+* Refer to the x.0.0 releases (e.g., v6.0.0) as *major*, x.x.0 releases (e.g.,
+  v6.1.0) as *minor*, and x.x.x releases (e.g., v6.1.2) as *bugfix* releases
+  (essentially `semantic versioning <https://semver.org>`_)
+* Use the x.x.0 format for the first major/minor release in a cycle, rather than
+  the x.x format previously used, as this is more standard practice with
+  semantic versioning.
+* Keep the default 6-month release cycle for non-bugfix releases, noting that in
+  line with `APE 2`_, minor versions can also be released more frequently if
+  needed.
+* Leave at least one year between major releases. If one year after the last
+  major release there are no breaking changes to be made (such as pending
+  deprecations to remove) then there is no need to release a major version.
+  The one year timescale for major releases is a minimum, not a fixed
+  interval.
 * Minimize as much as possible any changes that break API or change results in
-  minor releases, but be pragmatic and occasionally allow such changes if they would
-  not affect many users.
-* Add deprecation warnings or future warnings in minor and major releases but only
-  go through with the breaking changes in major releases (either the next major
-  release following when a warning was added, or subsequent ones if the changes
-  are deemed to be high impact enough to wait longer).
+  minor releases, but be pragmatic and occasionally allow such changes if they
+  would not affect many users.
+* Add deprecation warnings or future warnings in minor and major releases, and
+  make sure that these are present in released versions for a year before
+  carrying out the breaking changes in a major release. Therefore, if a deprecation
+  warning is added in a major release, the breaking changes can be made in the
+  following major release. If a deprecation warning is added a few months before
+  a major release, the breaking changes can only be made in the subsequent major
+  release.
 
 With this in place, we would effectively be striving to maximize stability over
-two-year periods but users would see deprecation warnings to prepare them for
+one-year periods but users would see deprecation warnings to prepare them for
 changes. This is in contrast to the current LTS system where users might not see
 a deprecation warning until the next LTS release as deprecations are not typically
 backported.
@@ -93,7 +101,7 @@ Guidelines on deprecations and API changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To avoid duplication, guidelines on deprecations and API changes as well as
-recommendations for communication with users will be added directly to APE 2.
+recommendations for communication with users will be added directly to `APE 2`_.
 
 Branches and pull requests
 --------------------------
@@ -106,7 +114,7 @@ Implementation
 This APE proposes to continue supporting the v5.0.x LTS series but to not
 designate v6.0.0 as LTS.
 
-Changes to APE 2 can be reviewed in https://github.com/astropy/astropy-APEs/pull/82
+Changes to `APE 2`_ can be reviewed in https://github.com/astropy/astropy-APEs/pull/82
 
 After acceptance of this APE, the documentation for the core package should be
 updated appropriately: https://github.com/astropy/astropy/pull/14713
@@ -127,3 +135,5 @@ Decision rationale
 ------------------
 
 <To be filled in by the coordinating committee when the APE is accepted or rejected>
+
+.. _APE 2: https://doi.org/10.5281/zenodo.1043887

--- a/APE21.rst
+++ b/APE21.rst
@@ -17,8 +17,9 @@ status: Discussion
 Abstract
 --------
 
-This APE proposes to no longer designate any releases of the core package as being
-"long-term support" (LTS) and provide guidance on how to handle API changes and deprecations.
+This APE proposes to no longer designate any releases of the core package as
+being "long-term support" (LTS) and provide guidance on how to handle API
+changes and deprecations.
 
 
 Detailed description
@@ -27,19 +28,19 @@ Detailed description
 Motivation
 ^^^^^^^^^^
 
-The original `APE 2: Astropy Release Cycle and Version Numbering <https://doi.org/10.5281/zenodo.1043887>`_
-describes the release cycle for the core astropy package, which consists of
-major releases every 6 months that add new features (e.g., v5.2), and releases
-in between this that are limited to fixing bugs or updating documentation (e.g.,
-v5.2.1). Every 2 years, major releases are designated as being LTS (e.g., v5.0)
-and we have committed to releasing bugfix releases for this version (e.g.,
-v5.0.3) for up to 2 years.
+The original `APE 2: Astropy Release Cycle and Version Numbering
+<https://doi.org/10.5281/zenodo.1043887>`_ describes the release cycle for the
+core astropy package, which consists of major releases every 6 months that add
+new features (e.g., v5.2), and releases in between this that are limited to
+fixing bugs or updating documentation (e.g., v5.2.1). Every 2 years, major
+releases are designated as being LTS (e.g., v5.0) and we have committed to
+releasing bugfix releases for this version (e.g., v5.0.3) for up to 2 years.
 
 At the start of the project, having LTS releases was critical for acceptance by
-large organizations/projects for which stability is paramount, as the core package went through
-significant API changes from version to version due to the youth of the project and LTS
-releases were a way to shield against these changes, or at least reduce disruption to
-be every 2 years.
+large organizations/projects for which stability is paramount, as the core
+package went through significant API changes from version to version due to the
+youth of the project and LTS releases were a way to shield against these
+changes, or at least reduce disruption to be every 2 years.
 
 LTS releases are however not without cost:
 
@@ -49,15 +50,15 @@ LTS releases are however not without cost:
   requiring human effort to manually do the backports, which can sometimes be
   non-trivial.
 * Even once fixes are backported to the LTS branch, carrying out releases is not
-  fully automated and requires manual steps, so having to do
-  bugfix releases for both the latest release branch and LTS branch puts an extra
-  burden on the core package release team.
+  fully automated and requires manual steps, so having to do bugfix releases for
+  both the latest release branch and LTS branch puts an extra burden on the core
+  package release team.
 
 In addition, it is not clear that LTS releases are needed anymore - now that the
 core package is over ten years old, it has reached a much higher level of
 stability. Most packages in the scientific Python ecosystem do not have LTS
-releases, and there is no longer a strong argument for having this
-in astropy either.
+releases, and there is no longer a strong argument for having this in astropy
+either.
 
 Proposed release procedure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -65,12 +66,15 @@ Proposed release procedure
 This APE proposes the following:
 
 * No longer designate any releases as LTS.
-* Keep the 6-month release cycle and bump releases to x.0 every 2 years (with
+* Keep the 6-month release cycle and bump releases to x.0.0 every 2 years (with
   the possibility of allowing this to be more or less than 2 years if there is a
   consensus amongst core package maintainers that this can be changed)
-* Refer to the x.0 releases every 2 years (e.g., v6.0) as "major"
-  releases, other releases every 6 months (e.g., v6.1) as "minor", and bug fixing
+* Refer to the x.0.0 releases every 2 years (e.g., v6.0.0) as "major"
+  releases, other releases every 6 months (e.g., v6.1.0) as "minor", and bug fixing
   releases (e.g., v6.1.2) as "bugfix" releases.
+* Use the x.x.0 format for the first major/minor release in a cycle, rather than the
+  x.x format previously used, as this is more standard practice in particular since
+  we will be essentially doing semantic versioning.
 * Minimize as much as possible any changes that break API or change results in
   minor releases, but be pragmatic and occasionally allow such changes if they would
   not affect many users.
@@ -105,7 +109,7 @@ designate v6.0.0 as LTS.
 Changes to APE 2 can be reviewed in https://github.com/astropy/astropy-APEs/pull/82
 
 After acceptance of this APE, the documentation for the core package should be
-updated appropriately.
+updated appropriately: https://github.com/astropy/astropy/pull/14713
 
 Backward compatibility
 ----------------------

--- a/APE21.rst
+++ b/APE21.rst
@@ -63,7 +63,7 @@ This APE proposes the following:
   releases, other releases every 6 months (e.g., v6.1) as "minor", and bug fixing
   releases (e.g., v6.1.2) as "bugfix" releases.
 * Minimize as much as possible any changes that break API or change results in
-  minor releases, but being pragmatic and accepting such changes if they would
+  minor releases, but be pragmatic and occasionally allow such changes if they would
   not affect many users.
 * Add deprecation warnings or future warnings in minor and major releases but only
   go through with the breaking changes in major releases (either the next major
@@ -75,6 +75,39 @@ two-year periods but users would see deprecation warnings to prepare them for
 changes. This is in contrast to the current LTS system where users might not see
 a deprecation warning until the next LTS release as deprecations are not typically
 backported.
+
+Guidelines on deprecations and API changes
+------------------------------------------
+
+The main guidelines are as follows:
+
+* API changes should only be carried out in major releases.
+* Any API changes should be preceded by deprecation warnings that should be
+  visible to users in at least one minor release cycle prior to the API change
+  being carried out.
+* New deprecations should not be introduced in bugfix releases - this will
+  ensure that deprecations will therefore be advertised for at least 6 months
+  before a major release.
+* If developers wish to make an API change at the point where the next release
+  is a major release, they should introduce the deprecation in the major release
+  and carry out the change in the following major release.
+
+As with all guidelines, there will be exceptions:
+
+* API changes can be carried out in major releases without deprecation if it is
+  not possible to have a deprecation phase.
+* Changes breaking or changing the behavior of code may be needed in order to
+  fix bugs. Such changes can be made in bugfix or minor releases and do not need
+  to be considered API changes.
+* Changes to exception types or warning/error messages may occasionally be
+  needed in non-major releases but these should be minimized as users may rely
+  on these and they may therefore be considered API
+
+These exceptions will require judgment calls on the part of maintainers, but any
+such changes should be clearly communicated to users (e.g., via the 'What's New' page).
+
+Communication with users
+------------------------
 
 Branches and pull requests
 --------------------------
@@ -95,9 +128,7 @@ N/A
 Alternatives
 ------------
 
-<Remove placeholder below before merge>
-If there were any alternative solutions to solving the same problem, they should
-be discussed here, along with a justification for the chosen approach.
+N/A
 
 Decision rationale
 ------------------

--- a/APE_LTS.rst
+++ b/APE_LTS.rst
@@ -91,7 +91,6 @@ Backward compatibility
 ----------------------
 
 N/A
-
 Alternatives
 ------------
 

--- a/APE_LTS.rst
+++ b/APE_LTS.rst
@@ -1,11 +1,11 @@
 Ending Long Term Support Releases
 ---------------------------------
 
-author: Thomas Robitaille
+author: Thomas Robitaille, Pey Lian Lim, Simon Conseil
 
-date-created: 2023 February 16 <replace with the date you submit the APE>
+date-created: 2023 February 16
 
-date-last-revised: 2023 February 16 <keep this up to date anytime something changes>
+date-last-revised: 2023 February 20 <keep this up to date anytime something changes>
 
 date-accepted: <replace with accepted date>
 
@@ -28,13 +28,13 @@ Detailed description
 for the core astropy package, which consists of major releases every 6 months that
 add new features (e.g., v5.2), and releases in between this that are limited to fixing bugs
 or updating documentation (e.g., v5.2.1). Every two years, major releases are designated
-as being 'long term support' (e.g., v5.0) and we have committed to releasing bugfix releases
+as being LTS (e.g., v5.0) and we have committed to releasing bugfix releases
 for this version (e.g., v5.0.3) for up to two years.
 
-At the start of the project, having long term support releases was critical for acceptance by
+At the start of the project, having LTS releases was critical for acceptance by
 large organizations/projects for which stability is paramount, as the core package went through
-significant API changes from version to version due to the youth of the project and long term
-support releases were a way to shield against these changes, or at least reduce disruption to
+significant API changes from version to version due to the youth of the project and LTS
+releases were a way to shield against these changes, or at least reduce disruption to
 be every two years.
 
 LTS releases are however not free:
@@ -44,7 +44,6 @@ LTS releases are however not free:
   branch and automated backports are more likely to fail as time goes on,
   requiring human effort to manually do the backports, which can sometimes be
   non-trivial.
-
 * Even once fixes are backported to the LTS branch, carrying out releases is not
   fully automated and requires manual steps, so having to do
   bugfix releases for both the latest release branch and LTS branch puts an extra
@@ -52,20 +51,20 @@ LTS releases are however not free:
 
 In addition, it is not clear that LTS releases are needed anymore - now that the
 core package is over ten years old, it has reached a much higher level of
-stability. No other main package in the scientific Python ecosystem has long
-term support releases, and there is no longer a strong argument for having this
+stability. No other main package in the scientific Python ecosystem has LTS
+releases, and there is no longer a strong argument for having this
 in astropy either.
 
 This APE proposes the following:
 
-* No longer designate any releases as LTS
-* Keep the 6-month release cycle and bump releases to x.0 every two years
-* Refer to the x.0 releases every two years (e.g. v6.0) as 'major'
-  releases, other releases every 6 months (e.g. v6.1) as 'minor', and bug fixing
-  releases (e.g. v6.1.2) as 'bugfix releases'
+* No longer designate any releases as LTS.
+* Keep the 6-month release cycle and bump releases to x.0 every two years.
+* Refer to the x.0 releases every two years (e.g., v6.0) as 'major'
+  releases, other releases every 6 months (e.g., v6.1) as 'minor', and bug fixing
+  releases (e.g., v6.1.2) as 'bugfix releases'.
 * Minimize as much as possible any changes that break API or change results in
   minor releases, but being pragmatic and accepting such changes if they would
-  not affect many users
+  not affect many users.
 * Add deprecation warnings or future warnings in minor and major releases but only
   go through with the breaking changes in major releases (either the next major
   release following when a warning was added, or subsequent ones if the changes
@@ -77,7 +76,6 @@ changes. This is in contrast to the current LTS system where users might not see
 a deprecation warning until the next LTS release as deprecations are not typically
 backported.
 
-
 Branches and pull requests
 --------------------------
 
@@ -86,22 +84,19 @@ N/A
 Implementation
 --------------
 
-This APE proposes to continue supporting the 5.0.x LTS series but to not
-designate 6.0 as LTS.
-
+This APE proposes to continue supporting the v5.0.x LTS series but to not
+designate v6.0 as LTS.
 
 Backward compatibility
 ----------------------
 
 N/A
 
-
 Alternatives
 ------------
 
 If there were any alternative solutions to solving the same problem, they should
 be discussed here, along with a justification for the chosen approach.
-
 
 Decision rationale
 ------------------

--- a/APE_LTS.rst
+++ b/APE_LTS.rst
@@ -1,0 +1,109 @@
+Ending Long Term Support Releases
+---------------------------------
+
+author: Thomas Robitaille
+
+date-created: 2023 February 16 <replace with the date you submit the APE>
+
+date-last-revised: 2023 February 16 <keep this up to date anytime something changes>
+
+date-accepted: <replace with accepted date>
+
+type: Process
+
+status: Discussion
+
+
+Abstract
+--------
+
+This APE proposes to no longer designate any releases of the core package as being
+'long term support' (LTS) and provide guidance on how to handle API changes and deprecations.
+
+
+Detailed description
+--------------------
+
+`APE 2: Astropy Release Cycle and Version Numbering <https://doi.org/10.5281/zenodo.1043887>`_ describes the release cycle
+for the core astropy package, which consists of major releases every 6 months that
+add new features (e.g., v5.2), and releases in between this that are limited to fixing bugs
+or updating documentation (e.g., v5.2.1). Every two years, major releases are designated
+as being 'long term support' (e.g., v5.0) and we have committed to releasing bugfix releases
+for this version (e.g., v5.0.3) for up to two years.
+
+At the start of the project, having long term support releases was critical for acceptance by
+large organizations/projects for which stability is paramount, as the core package went through
+significant API changes from version to version due to the youth of the project and long term
+support releases were a way to shield against these changes, or at least reduce disruption to
+be every two years.
+
+LTS releases are however not free:
+
+* While we use infrastructure to automate backporting fixes to release branches,
+  in practice the LTS branch diverges more and more from the main development
+  branch and automated backports are more likely to fail as time goes on,
+  requiring human effort to manually do the backports, which can sometimes be
+  non-trivial.
+
+* Even once fixes are backported to the LTS branch, carrying out releases is not
+  fully automated and requires manual steps, so having to do
+  bugfix releases for both the latest release branch and LTS branch puts an extra
+  burden on the core package release team.
+
+In addition, it is not clear that LTS releases are needed anymore - now that the
+core package is over ten years old, it has reached a much higher level of
+stability. No other main package in the scientific Python ecosystem has long
+term support releases, and there is no longer a strong argument for having this
+in astropy either.
+
+This APE proposes the following:
+
+* No longer designate any releases as LTS
+* Keep the 6-month release cycle and bump releases to x.0 every two years
+* Refer to the x.0 releases every two years (e.g. v6.0) as 'major'
+  releases, other releases every 6 months (e.g. v6.1) as 'minor', and bug fixing
+  releases (e.g. v6.1.2) as 'bugfix releases'
+* Minimize as much as possible any changes that break API or change results in
+  minor releases, but being pragmatic and accepting such changes if they would
+  not affect many users
+* Add deprecation warnings or future warnings in minor and major releases but only
+  go through with the breaking changes in major releases (either the next major
+  release following when a warning was added, or subsequent ones if the changes
+  are deemed to be high impact enough to wait longer).
+
+With this in place, we would effectively be striving to maximize stability over
+two year periods but users would see deprecation warnings to prepare them for
+changes. This is in contrast to the current LTS system where users might not see
+a deprecation warning until the next LTS release as deprecations are not typically
+backported.
+
+
+Branches and pull requests
+--------------------------
+
+N/A
+
+Implementation
+--------------
+
+This APE proposes to continue supporting the 5.0.x LTS series but to not
+designate 6.0 as LTS.
+
+
+Backward compatibility
+----------------------
+
+N/A
+
+
+Alternatives
+------------
+
+If there were any alternative solutions to solving the same problem, they should
+be discussed here, along with a justification for the chosen approach.
+
+
+Decision rationale
+------------------
+
+<To be filled in by the coordinating committee when the APE is accepted or rejected>


### PR DESCRIPTION
This is a draft and not ready for review - it follows the [related discussion on astropy-dev](https://groups.google.com/g/astropy-dev/c/QArGJfzPVeE). If you are interested in joining as a co-author please ping me!

- [x] Rename file to `APE_21.rst`

EDIT: Close #20 