### PR TITLE
APE0: Coco term limits and Ombudsperson

### DIFF
--- a/APE0.rst
+++ b/APE0.rst
@@ -216,19 +216,8 @@ temporarily take over the responsibilities of the Ombudsperson, should the need
 arise.
 
 The role of the "Astropy Ombudsperson" with all duties and responsibilities can
-also be performed by a group of people from different projects that pool resources.
-The Ombudsperson and the Coordination Committee can decide jointly for Astropy to
-join a group of NumFOCUS affiliated or sponsored projects, where each project
-delegates one representative; the Astropy Ombudsperson would then be the
-representative for Astropy.
-In this case, all members in this group shall be bound by the same
-expectation of confidentiality and impartiality; this group will then take up
-any ethical concerns, discuss and investigate violations of the code and conduct
-for the Astropy project in the same way the Astropy Ombudsperson would do if acting
-alone. Because being able to draw on the experience of other projects and
-having a group of people to look at problems from different perspectives is likely
-to lead to more fair and balanced outcomes, the Astropy Ombudsperson is encouraged
-to join such a group if one exists.
+also be performed by a group of people from Astropy and different open source projects
+that pool resources.
 
 .. On GitHub this anchor doesn't work.
 .. _votingmembers:

--- a/APE0.rst
+++ b/APE0.rst
@@ -152,8 +152,8 @@ term or decided to step down.
 Term
 ^^^^
 Each Coordination Committee member's term runs for three years from when
-the election results are finalized. After serving a full term, a Coordination
-Committee member must step down for at least one year before being eligible to
+the election results are finalized. After serving two full terms, a Coordination
+Committee member must step down for at least two years before being eligible to
 run again.
 
 In the case of a vacancy partway through a term, a by-election will be held.

--- a/APE0.rst
+++ b/APE0.rst
@@ -153,7 +153,7 @@ Term
 ^^^^
 Each Coordination Committee member's term runs for three years from when
 the election results are finalized. After serving two full terms, a Coordination
-Committee member must step down for at least two years before being eligible to
+Committee member must step down for at least one year before being eligible to
 run again.
 
 In the case of a vacancy partway through a term, a by-election will be held.

--- a/APE0.rst
+++ b/APE0.rst
@@ -142,7 +142,7 @@ least two weeks:
   they receive. If a tie occurs, it may be resolved by mutual agreement among
   the candidates, or else the winner will be chosen at random.
 
-The election process is managed by a non-voting Returns Officer nominated by
+The election process is managed by a Returns Officer nominated by
 the outgoing Coordination Committee, although the process (specific choice of
 website, etc) can be set up by the Coordination Committee or their delegates.
 For the initial election, the Returns Officer will be nominated by the NumFOCUS

--- a/APE0.rst
+++ b/APE0.rst
@@ -152,8 +152,9 @@ term or decided to step down.
 Term
 ^^^^
 Each Coordination Committee member's term runs for three years from when
-the election results are finalized. There is no limit to the number of terms that
-a single individual can be elected for.
+the election results are finalized. After serving a full term, a Coordination
+Committee member must step down for at least one year before being eligible to
+run again.
 
 In the case of a vacancy partway through a term, a by-election will be held.
 The term of the newly-elected member runs for the remainder of the term of

--- a/APE0.rst
+++ b/APE0.rst
@@ -204,7 +204,8 @@ an alternative point of contact for sensitive issues such as code of conduct
 violations and ethical concerns. Candidates for this project role are publicly
 nominated by the Coordination Committee, after which the Coordination Committee
 allows at least two weeks for comment, and then the nominee must be confirmed by
-two-thirds of the active `Voting Members`_.
+two-thirds of the active `Voting Members <votingmembers>`_.
+The Ombudsperson cannot be a member of the Coordination Committee.
 
 The Ombudsperson has no term limit but can resign at any time, or be removed by
 the same process as being confirmed: the Coordination Committee initiates, there
@@ -213,6 +214,21 @@ is a two-week comment period, and two-thirds of the active
 between removal/resignation and new appointment, the Coordination Committee will
 temporarily take over the responsibilities of the Ombudsperson, should the need
 arise.
+
+The role of the "Astropy Ombudsperson" with all duties and responsibilities can
+also be performed by a group of people from different projects that pool resources.
+The Ombudsperson and the Coordination Committee can decide jointly for Astropy to
+join a group of NumFOCUS affiliated or sponsored projects, where each project
+delegates one representative; the Astropy Ombudsperson would then be the
+representative for Astropy.
+In this case, all members in this group shall be bound by the same
+expectation of confidentiality and impartiality; this group will then take up
+any ethical concerns, discuss and investigate violations of the code and conduct
+for the Astropy project in the same way the Astropy Ombudsperson would do if acting
+alone. Because being able to draw on the experience of other projects and
+having a group of people to look at problems from different perspectives is likely
+to lead to more fair and balanced outcomes, the Astropy Ombudsperson is encouraged
+to join such a group if one exists.
 
 .. On GitHub this anchor doesn't work.
 .. _votingmembers:

--- a/APE0.rst
+++ b/APE0.rst
@@ -54,9 +54,8 @@ Composition
 ^^^^^^^^^^^
 The Coordination Committee is a committee that is composed of five
 members (this number was decided by vote at the same time as the first
-Coordination Committee election). Unless it would
-be short of candidates otherwise, it should not have more than one member from
-any particular employer. The Ombudsperson (described in
+Coordination Committee election).
+The Ombudsperson (described in
 Section 4) and the Coordination Committee will work to maintain this composition
 following the processes laid out in this Charter.
 


### PR DESCRIPTION
I want to suggest several changes to APE0. They touch different aspects of Astropy governance and should be voted on separately by the members. 

However, for the purpose of a discussion, it's much easier ot read in one document, thus I've put it all in one PR for now. The changes are:

## Coco: Only one person from each employer, unless...

I believe the original motivation for the requirement was to prevent any one employer to take over Astropy by stuffing the Coco with their staff. I think our experience has shown that this is trying to solve a problem that does not exist. Coco members act as individuals and not as representatives of their employer and the community will only vote for people they trust. On the other hand, large employers have very different centers, e.g. "a NASA employee" might be someone at a NASA center such as JPL or work thousands of miles away at NASA headquarters, so I don't see why we could not have two Coco members from the same employer. Then, there are centers where people might share an office but technically have separate employers (e.g. SAO/Harvard, or a faculty member on sabbatical at a different institution). Thus, this rule does not guarantee the diversity of the Coco - it's up to the members to vote in the right people.

Note that this change also removes the "unless it would be short of candidates otherwise" exception. While I initially suggested it, I now thinks it's a bad idea to have such an exception. Astropy is big enough that we can find candidates if we try. Having such an exception just reduces the motivation for the leadership to look to the right candidates and motivate them.

## Term limits for Coco

Instead of a "only one per employer" rule, I suggest a limit of one consecutive term. This will guarantee that the membership regularly chooses new leaders and that no one (and not any one institution) can dominate Astropy for too long. I do think people can be re-elected after a while, but it is important to cycle in and out of power to prevent a situation where Astropy relies too much on any one individual and that person becomes so crucial to running Astropy that, should that person leave the Project or take a different career, the Astropy Project itself suffers.

This is equally about team building and growing our capabilities. One of the most effective ways to "be part of the project" and "be really involved" is to be part of a leadership group such as the Coco that regularly meets to discuss issues. The Astropy project as a whole can only profit from having more people involved in that way; and once involved as Coco members, that experience stays with the project after the end of their term. Former Coco members are available for re-election after some time period or to help and advice in other roles. The fact that Coco terms are already staggered under the current APE0 guarantees that there is continuity and sharing of experience.


## returns officer for votes

Currently, we require the return officer for Coco election to be "non-voting". I suggest to remove this restriction. In practice, that means that we've always asked NumFOCUS staff to act as our returns officer and that is just additional complexity in organizing for little benefit. They don't have direct access to the list of email addresses for voting members, they don't know the timelines for APE0 by themselves, and they are not always available, e.g. we had to reschedule the 2023 Coco election because it happened too close in time to the NumFOCUS summit. So, in practice, we have to say "take this text and input it in this field, then press that button". On the other hand, there is nothing to gain from having the return officer be non-voting. The current APE0 does not specify that the returns officer is "external" or "neutral", only that they don't vote themselves, so it could be a project member, they just have to abstain from voting. As long as we use a secure voting system like helios where all voters get a receipt and can check the hash to see that the vote is counted correctly,it does not matter if the return officer is voting themselves or not; and if we use an insecure system (e.g. "just send a slack DM to the returns officer") then the returns officer could cheat weather or not they vote themselves.


## Share Ombudspeople between projects

It is hard to find qualified people for the job of Ombudsperson. Most if us join Astropy to code and advance research, not to mange interpersonal conflicts. That also means that most project members don't have experience or training in this role and, fortunately, the number of serious incidents is low, so that there is not a lot of on-the-job training either. On the other hand, the stakes are high, so we do not want to fill the Ombudsposition lightly.
At the same time, I believe that this really should not be any one person, but a group of people who perform the Ombuds duties together. In that way, they can discuss amongst themselves and in confidentiality any ethics concern or Code of conduct violation. A discussion between several people will almost certainly lead to a more balanced view than a single opinion. It also provides a back-up should an issue arise with the Ombudsperson themselves. If there is a group, an issue could be reported to other members of that group and the person accused can recuse themselves.

So, how do we find a group of Ombudspeople? I suggest to join forces with other NumFOCUS sponsored or affiliated projects and form a joint group of ~5 projects where each project sends one representative and then the 5 of them together act as "Ombuds" for all projects. I have discussed this idea at the NumFOCUS level and several other projects are interested. However, there is chicken-and-egg problem here: Until such a group exists, nobody can change their rules to join it, and as long as no project sets up their rules to join it, it won't exist. Thus, I'm suggesting changes to APE0 to empower the Astropy Ombuds to start / join such a group.

## Also see

https://groups.google.com/g/astropy-dev/c/d6ivOjaWl3s