### PR TITLE
Fix link to voting members

### DIFF
--- a/APE0.rst
+++ b/APE0.rst
@@ -41,10 +41,8 @@ users, and even potential participants in the broader astronomical and
 scientific software community. All have a vested interest in the success of the
 Project, so all governance in the end belongs to this community in its entirety.
 The governance Charter described below provides levels of delegation of that
-authority, particularly to the `Voting Members`__ and the
+authority, particularly to the `Voting Members <The Voting Members>`_ and the
 Coordination Committee.
-
-__ `The Voting Members`_
 
 The Coordination Committee
 --------------------------
@@ -130,11 +128,11 @@ least two weeks:
 
 * Phase 1, Nominations: Candidates will be nominated and confirm their interest
   in serving. Candidates can be nominated by anyone, including themselves, and
-  do not have to be `Voting Members`__ to be nominated.
+  do not have to be `Voting Members <The Voting Members>`_ to be nominated.
   Candidates should provide a brief statement in support of their candidacy,
   these statements should be made public as they are received during the
   nominations period.
-* Phase 2, Voting: Each `Voting Member`__ can vote for zero or
+* Phase 2, Voting: Each `Voting Member <The Voting Members>`_ can vote for zero or
   more of the candidates, up to the number of candidates. Voting is performed
   anonymously. Candidates who receive votes from a majority of the voting
   members participating in the election are ranked by the total number of votes
@@ -180,18 +178,18 @@ them for the duration of their term.
 
 Removing Members
 ^^^^^^^^^^^^^^^^
-In exceptional circumstances, the `Voting Members`__ may remove
+In exceptional circumstances, the `Voting Members <The Voting Members>`_ may remove
 one or more sitting Coordination Committee members via a single vote.
 
-Such a vote is triggered when a `Voting Member`__ calls for one
+Such a vote is triggered when a `Voting Member <The Voting Members>`_ calls for one
 publicly on an appropriate Project-wide communication channel, and two other
 active Voting Members second the proposal.
 
 For Coordination Committee Member(s) to be removed, two-thirds of the active
-`Voting Members`_APE_ (where the count *includes* the member being
+`Voting Members <The Voting Members>`_ (where the count *includes* the member being
 voted on if they are a voting member) must vote in support of the removal.
 
-To avoid repeated removal votes, any individual `Voting Member`__
+To avoid repeated removal votes, any individual `Voting Member <The Voting Members>`_
 who has called for, or seconded such a vote, may not call for or second a vote
 to remove any Coordination Committee member for one year from the original
 motion.
@@ -203,12 +201,12 @@ an alternative point of contact for sensitive issues such as code of conduct
 violations and ethical concerns. Candidates for this project role are publicly
 nominated by the Coordination Committee, after which the Coordination Committee
 allows at least two weeks for comment, and then the nominee must be confirmed by
-two-thirds of the active `Voting Members`__.
+two-thirds of the active `Voting Members <The Voting Members>`_.
 
 The Ombudsperson has no term limit but can resign at any time, or be removed by
 the same process as being confirmed: the Coordination Committee initiates, there
 is a two-week comment period, and two-thirds of the active
-`Voting Members`__ have to approve the removal. In the period
+`Voting Members <The Voting Members>`_ have to approve the removal. In the period
 between removal/resignation and new appointment, the Coordination Committee will
 temporarily take over the responsibilities of the Ombudsperson, should the need
 arise.
@@ -361,7 +359,7 @@ consensus of the community on accepting the final version.
 Changes to this Charter after it has been accepted should follow the
 modification process in `APE 1`_, with the exception that the final approval of
 the modification requires approval by a two-thirds vote of the
-`Voting Members`__ rather than approval by the Coordination
+`Voting Members <The Voting Members>`_ rather than approval by the Coordination
 Committee.
 
 Attribution and Acknowledgments

--- a/APE0.rst
+++ b/APE0.rst
@@ -41,8 +41,10 @@ users, and even potential participants in the broader astronomical and
 scientific software community. All have a vested interest in the success of the
 Project, so all governance in the end belongs to this community in its entirety.
 The governance Charter described below provides levels of delegation of that
-authority, particularly to the `Voting Members <votingmembers>`_ and the
+authority, particularly to the `Voting Members`__ and the
 Coordination Committee.
+
+__ `The Voting Members`_
 
 The Coordination Committee
 --------------------------
@@ -128,11 +130,11 @@ least two weeks:
 
 * Phase 1, Nominations: Candidates will be nominated and confirm their interest
   in serving. Candidates can be nominated by anyone, including themselves, and
-  do not have to be `Voting Members <votingmembers>`_ to be nominated.
+  do not have to be `Voting Members`__ to be nominated.
   Candidates should provide a brief statement in support of their candidacy,
   these statements should be made public as they are received during the
   nominations period.
-* Phase 2, Voting: Each `Voting Member <votingmembers>`_ can vote for zero or
+* Phase 2, Voting: Each `Voting Member`__ can vote for zero or
   more of the candidates, up to the number of candidates. Voting is performed
   anonymously. Candidates who receive votes from a majority of the voting
   members participating in the election are ranked by the total number of votes
@@ -178,18 +180,18 @@ them for the duration of their term.
 
 Removing Members
 ^^^^^^^^^^^^^^^^
-In exceptional circumstances, the `Voting Members <votingmembers>`_ may remove
+In exceptional circumstances, the `Voting Members`__ may remove
 one or more sitting Coordination Committee members via a single vote.
 
-Such a vote is triggered when a `Voting Member <votingmembers>`_ calls for one
+Such a vote is triggered when a `Voting Member`__ calls for one
 publicly on an appropriate Project-wide communication channel, and two other
 active Voting Members second the proposal.
 
 For Coordination Committee Member(s) to be removed, two-thirds of the active
-`Voting Members <votingmembers>`_ (where the count *includes* the member being
+`Voting Members`_APE_ (where the count *includes* the member being
 voted on if they are a voting member) must vote in support of the removal.
 
-To avoid repeated removal votes, any individual `Voting Member <votingmembers>`_
+To avoid repeated removal votes, any individual `Voting Member`__
 who has called for, or seconded such a vote, may not call for or second a vote
 to remove any Coordination Committee member for one year from the original
 motion.
@@ -201,27 +203,15 @@ an alternative point of contact for sensitive issues such as code of conduct
 violations and ethical concerns. Candidates for this project role are publicly
 nominated by the Coordination Committee, after which the Coordination Committee
 allows at least two weeks for comment, and then the nominee must be confirmed by
-two-thirds of the active `Voting Members <votingmembers>`_.
+two-thirds of the active `Voting Members`__.
 
 The Ombudsperson has no term limit but can resign at any time, or be removed by
 the same process as being confirmed: the Coordination Committee initiates, there
 is a two-week comment period, and two-thirds of the active
-`Voting Members <#votingmembers>`_ have to approve the removal. In the period
+`Voting Members`__ have to approve the removal. In the period
 between removal/resignation and new appointment, the Coordination Committee will
 temporarily take over the responsibilities of the Ombudsperson, should the need
 arise.
-
-Test Internal Links
--------------------
-
-* This is a link to votingmembers_.
-* This is a link to `Voting Members <votingmembers>`_.
-* This is a link to `Voting Members <The Voting Members>`_.
-* This is a link to `The Voting Members`_.
-* This is a link to `Voting Members`__.
-
-__ `The Voting Members`_
-
 
 .. On GitHub this anchor doesn't work.
 .. _votingmembers:
@@ -371,7 +361,7 @@ consensus of the community on accepting the final version.
 Changes to this Charter after it has been accepted should follow the
 modification process in `APE 1`_, with the exception that the final approval of
 the modification requires approval by a two-thirds vote of the
-`Voting Members <votingmembers>`_ rather than approval by the Coordination
+`Voting Members`__ rather than approval by the Coordination
 Committee.
 
 Attribution and Acknowledgments

--- a/APE0.rst
+++ b/APE0.rst
@@ -216,11 +216,14 @@ Test Internal Links
 
 * This is a link to votingmembers_.
 * This is a link to `Voting Members <votingmembers>`_.
+* This is a link to `Voting Members <The Voting Members>`_.
 * This is a link to `The Voting Members`_.
 * This is a link to `Voting Members`__.
 
-__ votingmembers_
+__ `The Voting Members`_
 
+
+.. On GitHub this anchor doesn't work.
 .. _votingmembers:
 
 The Voting Members

--- a/APE0.rst
+++ b/APE0.rst
@@ -153,9 +153,9 @@ Each Coordination Committee member's term runs for three years from when
 the election results are finalized. There is no limit to the number of terms that
 a single individual can be elected for.
 
-In the case of a vacancy partway through a term, a by-election will be held. 
+In the case of a vacancy partway through a term, a by-election will be held.
 The term of the newly-elected member runs for the remainder of the term of
-the member they are replacing. 
+the member they are replacing.
 
 For the initial election of Coordination Committee members, two seats will have
 terms of one year, two have a term of two years, and one has a term of three
@@ -211,6 +211,15 @@ between removal/resignation and new appointment, the Coordination Committee will
 temporarily take over the responsibilities of the Ombudsperson, should the need
 arise.
 
+Test Internal Links
+-------------------
+
+* This is a link to votingmembers_.
+* This is a link to `Voting Members <votingmembers>`_.
+* This is a link to `The Voting Members`_.
+* This is a link to `Voting Members`__.
+
+__ votingmembers_
 
 .. _votingmembers:
 

--- a/APE0.rst
+++ b/APE0.rst
@@ -41,8 +41,11 @@ users, and even potential participants in the broader astronomical and
 scientific software community. All have a vested interest in the success of the
 Project, so all governance in the end belongs to this community in its entirety.
 The governance Charter described below provides levels of delegation of that
-authority, particularly to the `Voting Members <The Voting Members>`_ and the
+authority, particularly to the `Voting Members`_ and the
 Coordination Committee.
+
+.. _`Voting Members`: #the-voting-members
+.. _`Voting Member`: #the-voting-members
 
 The Coordination Committee
 --------------------------
@@ -128,11 +131,11 @@ least two weeks:
 
 * Phase 1, Nominations: Candidates will be nominated and confirm their interest
   in serving. Candidates can be nominated by anyone, including themselves, and
-  do not have to be `Voting Members <The Voting Members>`_ to be nominated.
+  do not have to be `Voting Members`_ to be nominated.
   Candidates should provide a brief statement in support of their candidacy,
   these statements should be made public as they are received during the
   nominations period.
-* Phase 2, Voting: Each `Voting Member <The Voting Members>`_ can vote for zero or
+* Phase 2, Voting: Each `Voting Member`_ can vote for zero or
   more of the candidates, up to the number of candidates. Voting is performed
   anonymously. Candidates who receive votes from a majority of the voting
   members participating in the election are ranked by the total number of votes
@@ -178,18 +181,18 @@ them for the duration of their term.
 
 Removing Members
 ^^^^^^^^^^^^^^^^
-In exceptional circumstances, the `Voting Members <The Voting Members>`_ may remove
+In exceptional circumstances, the `Voting Members`_ may remove
 one or more sitting Coordination Committee members via a single vote.
 
-Such a vote is triggered when a `Voting Member <The Voting Members>`_ calls for one
+Such a vote is triggered when a `Voting Member`_ calls for one
 publicly on an appropriate Project-wide communication channel, and two other
 active Voting Members second the proposal.
 
 For Coordination Committee Member(s) to be removed, two-thirds of the active
-`Voting Members <The Voting Members>`_ (where the count *includes* the member being
+`Voting Members`_ (where the count *includes* the member being
 voted on if they are a voting member) must vote in support of the removal.
 
-To avoid repeated removal votes, any individual `Voting Member <The Voting Members>`_
+To avoid repeated removal votes, any individual `Voting Member`_
 who has called for, or seconded such a vote, may not call for or second a vote
 to remove any Coordination Committee member for one year from the original
 motion.
@@ -201,12 +204,12 @@ an alternative point of contact for sensitive issues such as code of conduct
 violations and ethical concerns. Candidates for this project role are publicly
 nominated by the Coordination Committee, after which the Coordination Committee
 allows at least two weeks for comment, and then the nominee must be confirmed by
-two-thirds of the active `Voting Members <The Voting Members>`_.
+two-thirds of the active `Voting Members`_.
 
 The Ombudsperson has no term limit but can resign at any time, or be removed by
 the same process as being confirmed: the Coordination Committee initiates, there
 is a two-week comment period, and two-thirds of the active
-`Voting Members <The Voting Members>`_ have to approve the removal. In the period
+`Voting Members`_ have to approve the removal. In the period
 between removal/resignation and new appointment, the Coordination Committee will
 temporarily take over the responsibilities of the Ombudsperson, should the need
 arise.
@@ -359,7 +362,7 @@ consensus of the community on accepting the final version.
 Changes to this Charter after it has been accepted should follow the
 modification process in `APE 1`_, with the exception that the final approval of
 the modification requires approval by a two-thirds vote of the
-`Voting Members <The Voting Members>`_ rather than approval by the Coordination
+`Voting Members`_ rather than approval by the Coordination
 Committee.
 
 Attribution and Acknowledgments


### PR DESCRIPTION
This PR fixes #88.

I had to experiment with several different types of internal RST links. I suspect that GitHub may be interpreting RST somewhat differently from, *e.g.* Spinx, but I found a type of internal link that does seem to work when rendered on GitHub.