### PR TITLE
Readme update for APE22 and instruction fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,7 @@ Accepted APEs
 19  `Distributing Astropy Project Funding`_                          2022-Feb-28 |APE 19 DOI|
 20  `Formatting Code with Black`_                                    2022-Sep-23 |APE 20 DOI|
 21  `Ending Long Term Support Releases`_                             2023-May-31 |APE 21 DOI|
+21  `Astropy Affiliated Packages with pyOpenSci`_                    2024-Jan-29 |APE 22 DOI|
 === ================================================================ =========== ============
 
 .. _The Astropy Project Governance Charter: https://github.com/astropy/astropy-APEs/blob/main/APE0.rst
@@ -57,6 +58,7 @@ Accepted APEs
 .. _Distributing Astropy Project Funding: https://github.com/astropy/astropy-APEs/blob/main/APE19.rst
 .. _Formatting Code with Black: https://github.com/astropy/astropy-APEs/blob/main/APE20.rst
 .. _Ending Long Term Support Releases: https://github.com/astropy/astropy-APEs/blob/main/APE21.rst
+.. _Astropy Affiliated Packages with pyOpenSci: https://github.com/astropy/astropy-APEs/blob/main/APE22.rst
 
 .. |APE 0 DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4552790.svg
    :target: https://doi.org/10.5281/zenodo.4552790
@@ -117,6 +119,9 @@ Accepted APEs
 
 .. |APE 21 DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.7990988.svg
    :target: https://doi.org/10.5281/zenodo.7990988
+
+.. |APE 22 DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.10581892.svg
+   :target: https://doi.org/10.5281/zenodo.10581891
 
 Proposing a new APE
 ^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -152,18 +152,20 @@ Coordination Committee.  Once the community discussion on the APE has wound
 down, the committee discusses the APE and makes a final decision on acceptance
 or rejection.  One of the committee members should then:
 
-1. Fill in the "Decision rationale" section of the APE with a description of why
+#. Fill in the "Decision rationale" section of the APE with a description of why
    the APE was accepted or rejected, including a summary of the community's
    discussion as relevant.
-2. Update the "date-last-revised" to the day of merging and "status" to
+#. Update the "date-last-revised" to the day of merging and "status" to
    "Accepted" or "Rejected".
-3. If necessary, rename the APE file to be ``APE##.rst``, where ## is the next
+#. If necessary, rename the APE file to be ``APE##.rst``, where ## is the next
    free number on the list of APEs.
 #. Leave a brief comment in the PR indicating the result.
 #. Merge the PR with the above changes.
-#. If the APE was accepted then continue with the remaining steps, otherwise stop now.
-#. Upload the APE to Zenodo to give it a DOI.  Go to https://zenodo.org/deposit/new, upload
-   the .rst file, and set the fields to the following:
+#. If the APE was accepted then continue with the remaining steps, otherwise 
+   stop now.
+#. Upload the APE to Zenodo to give it a DOI.  Log into the astropy team Zenodo
+   account (*not your personal account*), go to https://zenodo.org/deposit/new,
+   upload the .rst file, and set the fields to the following:
 
    ============================= ======================================================
    Zenodo field                  Set to


### PR DESCRIPTION
This updates the README both to include APE22 in the index (#87).  It also updates the instructions a bit, as I realized while following them that it doesn't explicitly state we should use the shared account.