### PR TITLE
APE 1: Proposal filename should be descriptive (naming chaos fix 1)

### DIFF
--- a/APE1.rst
+++ b/APE1.rst
@@ -1,11 +1,11 @@
 APE Purpose and Process
 -----------------------
 
-author: Perry Greenfield
+author: Perry Greenfield, Lia Corrales, Thomas Robitaille, Erik Tollerud, Pey Lian Lim
 
 date-created: 2013 October 11
 
-date-last-revised: 2021 February 26
+date-last-revised: 2024 February 5
 
 date-accepted: 2013 November 8
 
@@ -13,7 +13,10 @@ type: Process
 
 status: Accepted
 
-revised-by: Lia Corrales, Thomas Robitaille, Erik Tollerud - 2021 February 26 - Added APE modification process
+revised-by:
+
+* Lia Corrales, Thomas Robitaille, Erik Tollerud - 2021 February 26 - Added APE modification process
+* Pey Lian Lim - 2024 February 5 - Added APE numbering process
 
 Abstract
 --------
@@ -83,8 +86,11 @@ APE-able. Posting to the astropy-dev mailing list is the best way to go about
 doing this.
 
 Following a discussion on astropy-dev, the proposal should be submitted as a
-pull request to astropy-APEs with the name APE<n>.rst where <n> is an
-appropriately assigned number. The draft must use the APEtemplate.rst file.
+pull request to astropy-APEs with the name <description>.rst where <description> is a
+concise short description of its purpose. At the time of acceptance, <description>.rst
+would be renamed to APE<n>.rst by the CoCo member doing the PR merge, where <n>
+is the next available number in the listing of accepted APEs.
+The draft must follow the APEtemplate.rst file.
 That a formal proposal has been submitted as a PR should be announced to the
 astropy-dev list.
 
@@ -192,3 +198,4 @@ Previous versions of this APE
 -----------------------------
 
 * 2013-11-08 [`DOI <http://doi.org/10.5281/zenodo.1043886>`_] [`GitHub <https://github.com/astropy/astropy-APEs/blob/42951733ac42c0ea178d8df30705274a43c93091/APE1.rst>`_]
+* 2021-03-09 [`GitHub <https://github.com/astropy/astropy-APEs/commit/f2afc2ec72575d3c592b3a5c6257117b07b5b755>`_]

--- a/README.rst
+++ b/README.rst
@@ -148,17 +148,17 @@ Finalizing APEs
 ^^^^^^^^^^^^^^^
 
 The final decision on accepting or rejecting APEs lies with the Astropy
-Coordination Committee.  Once the community discussion on the APE has wound
+Coordination Committee (CoCo).  Once the community discussion on the APE has wound
 down, the committee discusses the APE and makes a final decision on acceptance
 or rejection.  One of the committee members should then:
 
+#. Rename the APE file to be ``APE##.rst``, where ## is the next
+   free number on the list of accepted APEs.
 #. Fill in the "Decision rationale" section of the APE with a description of why
    the APE was accepted or rejected, including a summary of the community's
    discussion as relevant.
 #. Update the "date-last-revised" to the day of merging and "status" to
    "Accepted" or "Rejected".
-#. If necessary, rename the APE file to be ``APE##.rst``, where ## is the next
-   free number on the list of APEs.
 #. Leave a brief comment in the PR indicating the result.
 #. Merge the PR with the above changes.
 #. If the APE was accepted then continue with the remaining steps, otherwise 
@@ -198,7 +198,7 @@ or rejection.  One of the committee members should then:
 Updating APEs
 ^^^^^^^^^^^^^
 
-In the cases where an updated APE requires updating (e.g. references to a  new
+In the cases where an updated APE requires updating (e.g., references to a new
 APE that supercedes it, clarifying information that emerges after the APE is
 accepted, etc.), changes can be made directly via PR, but the
 "date-last-revised" should be updated in the APE. Additionally, the Zenodo entry


### PR DESCRIPTION
Motivation: Asking people to put a number in APE proposal filename too early and then changing the number last minute can cause merge conflict (for another open APE proposal) and confusion (for everyone else).

Case study:

* #87 (advertised as APE 24 for many months but merged as APE 22)
* #85 (advertised as APE 22 that can now never be)

But why are we renaming? To prevent gaps in accepted APE listing (e.g., the still open #14 and the missing APE 11 in the list of accepted APEs).

Proposed solution: Update APE 1 to ask APE proposal authors to not use a number at all. Now, the numbering will only be assigned at merge time by a CoCo member doing the merge.

Pros: No more numbering confusing or gaps.
Cons: Renaming a file last minute makes for ugly commit history and weird `git blame`. Also cannot say "APE short-number" in discussions until after it is accepted.