### PR TITLE
APE 1: Number is gone once reserved (naming chaos fix 2)

### DIFF
--- a/APE1.rst
+++ b/APE1.rst
@@ -1,11 +1,11 @@
 APE Purpose and Process
 -----------------------
 
-author: Perry Greenfield
+author: Perry Greenfield, Lia Corrales, Thomas Robitaille, Erik Tollerud, Pey Lian Lim
 
 date-created: 2013 October 11
 
-date-last-revised: 2021 February 26
+date-last-revised: 2024 February 5
 
 date-accepted: 2013 November 8
 
@@ -13,7 +13,10 @@ type: Process
 
 status: Accepted
 
-revised-by: Lia Corrales, Thomas Robitaille, Erik Tollerud - 2021 February 26 - Added APE modification process
+revised-by:
+
+* Lia Corrales, Thomas Robitaille, Erik Tollerud - 2021 February 26 - Added APE modification process
+* Pey Lian Lim - 2024 February 5 - Added APE numbering process
 
 Abstract
 --------
@@ -84,7 +87,8 @@ doing this.
 
 Following a discussion on astropy-dev, the proposal should be submitted as a
 pull request to astropy-APEs with the name APE<n>.rst where <n> is an
-appropriately assigned number. The draft must use the APEtemplate.rst file.
+appropriately assigned number (i.e., not already an accepted/proposed/rejected APE).
+The draft must follow the APEtemplate.rst file.
 That a formal proposal has been submitted as a PR should be announced to the
 astropy-dev list.
 
@@ -192,3 +196,4 @@ Previous versions of this APE
 -----------------------------
 
 * 2013-11-08 [`DOI <http://doi.org/10.5281/zenodo.1043886>`_] [`GitHub <https://github.com/astropy/astropy-APEs/blob/42951733ac42c0ea178d8df30705274a43c93091/APE1.rst>`_]
+* 2021-03-09 [`GitHub <https://github.com/astropy/astropy-APEs/commit/f2afc2ec72575d3c592b3a5c6257117b07b5b755>`_]

--- a/APE1.rst
+++ b/APE1.rst
@@ -1,7 +1,7 @@
 APE Purpose and Process
 -----------------------
 
-author: Perry Greenfield, Lia Corrales, Thomas Robitaille, Erik Tollerud, Pey Lian Lim
+author: Perry Greenfield
 
 date-created: 2013 October 11
 
@@ -88,7 +88,7 @@ doing this.
 Following a discussion on astropy-dev, the proposal should be submitted as a
 pull request to astropy-APEs with the name APE<n>.rst where <n> is an
 appropriately assigned number (i.e., not already an accepted/proposed/rejected APE).
-The draft must follow the APEtemplate.rst file.
+The draft must use the APEtemplate.rst file.
 That a formal proposal has been submitted as a PR should be announced to the
 astropy-dev list.
 

--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,7 @@ Finalizing APEs
 ^^^^^^^^^^^^^^^
 
 The final decision on accepting or rejecting APEs lies with the Astropy
-Coordination Committee.  Once the community discussion on the APE has wound
+Coordination Committee (CoCo).  Once the community discussion on the APE has wound
 down, the committee discusses the APE and makes a final decision on acceptance
 or rejection.  One of the committee members should then:
 
@@ -158,7 +158,7 @@ or rejection.  One of the committee members should then:
 #. Update the "date-last-revised" to the day of merging and "status" to
    "Accepted" or "Rejected".
 #. If necessary, rename the APE file to be ``APE##.rst``, where ## is the next
-   free number on the list of APEs.
+   free number on the list of APEs. Only do this if there is a conflict.
 #. Leave a brief comment in the PR indicating the result.
 #. Merge the PR with the above changes.
 #. If the APE was accepted then continue with the remaining steps, otherwise 
@@ -198,7 +198,7 @@ or rejection.  One of the committee members should then:
 Updating APEs
 ^^^^^^^^^^^^^
 
-In the cases where an updated APE requires updating (e.g. references to a  new
+In the cases where an updated APE requires updating (e.g., references to a new
 APE that supercedes it, clarifying information that emerges after the APE is
 accepted, etc.), changes can be made directly via PR, but the
 "date-last-revised" should be updated in the APE. Additionally, the Zenodo entry


### PR DESCRIPTION
Motivation: Asking people to put a number in APE proposal filename too early and then changing the number last minute can cause merge conflict (for another open APE proposal) and confusion (for everyone else).

Case study:

* #87 (advertised as APE 24 for many months but merged as APE 22)
* #85 (advertised as APE 22 that can now never be)

But why are we renaming? To prevent gaps in accepted APE listing (e.g., the still open #14 and the missing APE 11 in the list of accepted APEs).

But are gaps really a big deal? In PEP (Python), they don't do re-numbering. And maybe neither in NEP (NumPy).

Proposed solution: As long as APE author follows the rules and use the next available number properly, the number is considered taken and cannot be reused. If the proposal is rejected, it either appears as a gap in the README or CoCo can say that APE number was rejected. Exception can be made to re-use a number if the proposal PR is closed as invalid/spam. If APE author uses an invalid number, reviewer would point that out very early in the review process (I think that is already status quo at the time of writing this PR).

Pros: No more numbering confusion.
Cons: Might end up with a lot of gaps in the listing of accepted APEs. For example, people will keep wondering what happened to APE 11 like we do with Windows 9.


Alternative:

* #96 

More discussion: https://groups.google.com/g/astropy-dev/c/7Tnx7S3aGP4