### PR TITLE
APE0 modification: clarify that modifying roles itself requires two week comment period

### DIFF
--- a/APE0.rst
+++ b/APE0.rst
@@ -101,7 +101,7 @@ should look for ways to use its authority as little as possible, striving
 to involve the community in decisions whenever possible, and delegating
 responsibilities.
 
-When delegating its authority to create roles or make appointments, the
+When delegating its authority by creating roles or making appointments, the
 Coordination Committee must solicit community feedback for no less than two
 weeks.
 


### PR DESCRIPTION
This is a very small change that I think makes APE0 clearer.  It's not really worth the trouble of an APE0 change on its own, but I'm proposing this because tat the 2024 Coordination Meeting we agreed #89 would be done as multiple votes in the next election round, so this PR can be added as just one more vote.

(The actual change itself also came from some discussions at the 2024 Coordination Meeting)

The change is not meant to be substantive, but rather to clarify that how we have been interpreting this sentences is what APE0 actually meant. That is, it was *intended* that the two week period apply to creating roles and making appointments, and the as-written wording was just ambiguous what the "to" applies to.