### PR TITLE
APE26: Removing data storage (representations) from coordinate frames 

### DIFF
--- a/APE26.rst
+++ b/APE26.rst
@@ -117,10 +117,13 @@ is the more important consideration. In this arena too,
 separating frames from data storage has its advantages. Perhaps
 most importantly, documentation will be more obvious: the methods
 and attributes are defined on ``SkyCoord`` (and ``Coordinate``)
-proper, so `Sphinx <https://www.sphinx-doc.org/>`_ will know how to typeset those, while type
+proper, so `Sphinx <https://www.sphinx-doc.org/>`_ will know how 
+to typeset those, while type
 checkers can help users in finding and using them properly. It
-will also be easier: following the `Zen of Python <https://peps.python.org/pep-0020/>`_, "There should be
-one-- and preferably only one --obvious way to do it." The present overlap leads to
+will also be easier: following the 
+`Zen of Python <https://peps.python.org/pep-0020/>`_, "There should 
+be one-- and preferably only one --obvious way to do it." The 
+present overlap leads to
 confusion wherein beginner users end up creating
 ``BaseCoordinateFrame`` objects such as ``ICRS``, when the docs
 are clear that these are for more advanced users and that
@@ -254,7 +257,9 @@ substeps).
    enabling automatic conversion of the with-data frames into 
    ``SkyCoord`` objects.
 
-4. Deprecating the legacy with-data frame classes, and eventually removing them after a deprecation period that adheres to `APE 2 <https://github.com/astropy/astropy-APEs/blob/main/APE2.rst>`_.
+4. Deprecating the legacy with-data frame classes, and eventually 
+   removing them after a deprecation period that adheres to 
+   `APE 2 <https://github.com/astropy/astropy-APEs/blob/main/APE2.rst>`_.
 
    - Emitting warnings when instantiated.
 
@@ -263,7 +268,7 @@ substeps).
 
    - Remove.
 
-The third step (at stage 3a) is illustrated in the following 
+The fourth step is illustrated in the following 
 pseudocode:
 
 .. code-block:: python

--- a/APE26.rst
+++ b/APE26.rst
@@ -12,30 +12,94 @@ Authors (alphabetical): Jeff Jennings, Adrian Price-Whelan, Nathaniel Starkman, 
 
 Abstract
 --------
-Coordinate frames in astropy.coordinates currently store metadata used to construct the frame (i.e. for transforming between frames) and may also store coordinate *data* itself. This duplicates functionality with `SkyCoord`, which acts as a container for both coordinate data and reference frame information. We propose to change the frame classes such that they only store metadata and never coordinate data. This would make the implementation more modular, remove ambiguity for users from having nearly duplicate functionality with slightly different APIs, and better satisfy the principle of Separation of Concerns.
+Coordinate frames in astropy.coordinates currently store metadata used to construct the 
+frame (i.e. for transforming between frames) and may also store coordinate *data* itself. 
+This duplicates functionality with ``SkyCoord``, which acts as a container for both 
+coordinate data and reference frame information. We propose to change the frame classes 
+such that they only store metadata and never coordinate data. This would make the 
+implementation more modular, remove ambiguity for users from having nearly duplicate 
+functionality with slightly different APIs, and better satisfy the principle of 
+Separation of Concerns.
 
 Detailed description
 --------------------
-The coordinate frame classes (subclasses of `BaseCoordinateFrame`, e.g., `ICRS`, `Galactic`, `FK4`, etc.) are used to represent astronomical reference frames. These may also contain position, velocity, time, or other information about the reference frame relative to another reference frame, which is used to transform coordinates between the reference frames that exist in the `astropy.coordinates` ecosystem. For example, the `AltAz` frame class, which is used when referencing sky coordinates in altitude and azimuth, must contain a location on Earth and a time in order to transform to and from a fixed reference frame like the ICRS. In addition to reference frame information, these frame classes can **also** contain coordinate data (positions, velocities, or other differentials), which are stored internally using the `Representation` and `Differential` classes.
+The coordinate frame classes (subclasses of ``BaseCoordinateFrame``, e.g., ``ICRS``, 
+``Galactic``, ``FK4``, etc.) are used to represent astronomical reference frames. These 
+may also contain position, velocity, time, or other information about the reference frame 
+relative to another reference frame, which is used to transform coordinates between the 
+reference frames that exist in the ``astropy.coordinates`` ecosystem. For example, the 
+``AltAz`` frame class, which is used when referencing sky coordinates in altitude and 
+azimuth, must contain a location on Earth and a time in order to transform to and from a 
+fixed reference frame like the ICRS. In addition to reference frame information, these 
+frame classes can **also** contain coordinate data (positions, velocities, or other 
+differentials), which are stored internally using the ``Representation`` and 
+``Differential`` classes.
 
-The above reveals a problematic oddity with the coordinate frame implementation – an insufficient `separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`_. The coordinate frame class deals with two separate issues: the definition of the frame and the storage of coordinate data within that frame. Ideally the code would be more modularly structured, where the coordinate frame class **only** defines the reference frame. It would then be the purview of another class – `SkyCoord` – to bring these concerns together and to represent data (using `Representation` and `Differential` classes) in a given reference frame (using a `CoordinateFrame` class). As a demonstration of the current state of duplicated functionality, these two initializations effectively represent the same thing, but return different objects with similar but not identical APIs:
+The above reveals a problematic oddity with the coordinate frame implementation – an 
+insufficient `separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`_. 
+The coordinate frame class deals with two separate issues: the definition of the frame 
+and the storage of coordinate data within that frame. Ideally the code would be more 
+modularly structured, where the coordinate frame class **only** defines the reference 
+frame. It would then be the purview of another class – `SkyCoord` – to bring these 
+concerns together and to represent data (using `Representation` and `Differential` 
+classes) in a given reference frame (using a `CoordinateFrame` class). As a demonstration 
+of the current state of duplicated functionality, these two initializations effectively 
+represent the same thing, but return different objects with similar but not identical 
+APIs:
 
 .. code-block:: python
 
     c1 = SkyCoord(1., 2., frame="icrs", units="deg")
     c2 = ICRS(1. * u.deg, 2. * u.deg)
 
-We suggest the situation should instead be analogous to what is the case for units, which know how to transform from one to another, but are not concerned with how the values are stored (that belongs to `Quantity`). Translating to coordinates, units are like `CoordinateFrame`, the values are the coordinate data (`Representations`), and `Quantity` is like `SkyCoord`.
+We suggest the situation should instead be analogous to what is the case for units, 
+which know how to transform from one to another, but are not concerned with how the 
+values are stored (that belongs to ``Quantity``). Translating to coordinates, units are 
+like ``CoordinateFrame``, the values are the coordinate data (``Representations``), and 
+``Quantity`` is like ``SkyCoord``.
 
-Having both the frame classes as well as `SkyCoord` be able to store and handle data has resulted in a large amount of code duplication. Restructuring the `Frame` classes to remove data storage will allow for much more maintainable, de-duplicated code. It will also make it easier to contribute: if there is a problem one would like to solve in a given method, if one looks in `SkyCoord`, one will likely find that it does not exist, but instead is defined on `BaseCoordinateFrame` and gets dynamically called via `SkyCoord.__getattr__`. Indeed, the construction of `BaseCoordinateFrame` ends up complicating `SkyCoord`, which has to manage the coordinate data **through** the stored BaseCoordinateFrame.
+Having both the frame classes as well as ``SkyCoord`` be able to store and handle data 
+has resulted in a large amount of code duplication. Restructuring the ``Frame`` classes 
+to remove data storage will allow for much more maintainable, de-duplicated code. It 
+will also make it easier to contribute: if there is a problem one would like to solve 
+in a given method, if one looks in ``SkyCoord``, one will likely find that it does not 
+exist, but instead is defined on ``BaseCoordinateFrame`` and gets dynamically called via 
+``SkyCoord.__getattr__``. Indeed, the construction of ``BaseCoordinateFrame`` ends up 
+complicating ``SkyCoord``, which has to manage the coordinate data **through** the stored 
+``BaseCoordinateFrame``.
 
-Another issue with the current implementation of coordinate frames is that the optional inclusion of coordinate data makes the reference frames “multi-modal”. This creates different usage modes (with and without data), each exhibiting different behavior. For instance, some methods such as `separation` work fine with frames with data, while doing this on coordinate frames without data results in an error. This kind of multi-modal structure is considered an anti-pattern because it forces any code interacting with the frame classes to handle both cases (checking `frame.has_data`), complicating the codebase unnecessarily.
+Another issue with the current implementation of coordinate frames is that the optional 
+inclusion of coordinate data makes the reference frames “multi-modal”. This creates 
+different usage modes (with and without data), each exhibiting different behavior. For 
+instance, some methods such as ``separation`` work fine with frames with data, while 
+doing this on coordinate frames without data results in an error. This kind of 
+multi-modal structure is considered an anti-pattern because it forces any code 
+interacting with the frame classes to handle both cases (checking ``frame.has_data``), 
+complicating the codebase unnecessarily.
 
-All the points discussed thus far – separation of concerns and code duplication – concern maintainers. However user experience is the more important consideration. In this arena too, separating frames from data storage has its advantages. Perhaps most importantly, documentation will be more obvious: the methods and attributes are defined on `SkyCoord`, and sphinx will know how to typeset those. It will also be easier: following the Zen of Python, there should be one clear way to do something. The present overlap leads to confusion where beginner users end up creating `BaseCoordinateFrame` objects such as `ICRS`, when the docs are clear that these are for more advanced users and that `SkyCoord` is to be preferred. The system will also be less fragile. For example, if users manipulate the internal workings of `SkyCoord` (which is discouraged but possible), the coordinate data can become decoupled from the caching that `SkyCoord` performs for speed.
+All the points discussed thus far – separation of concerns and code duplication – 
+concern maintainers. However user experience is the more important consideration. In 
+this arena too, separating frames from data storage has its advantages. Perhaps most 
+importantly, documentation will be more obvious: the methods and attributes are defined 
+on ``SkyCoord``, and sphinx will know how to typeset those. It will also be easier: 
+following the Zen of Python, there should be one clear way to do something. The present 
+overlap leads to confusion where beginner users end up creating ``BaseCoordinateFrame`` 
+objects such as ``ICRS``, when the docs are clear that these are for more advanced users 
+and that ``SkyCoord`` is to be preferred. The system will also be less fragile. For 
+example, if users manipulate the internal workings of ``SkyCoord`` (which is discouraged 
+but possible), the coordinate data can become decoupled from the caching that ``SkyCoord`` 
+performs for speed.
 
 Finished Product
 ----------------
-The end result of the implementation of this APE will be that coordinate frame classes only hold information pertaining to the reference frame they represent and never actual coordinate data in that reference frame. This is consistent with our mathematical framework, the reference frame mediates how coordinate data is understood (e.g. distance measures) or interacts (e.g. separation from other coordinates), but the coordinate data itself is actually independent of that information. Classes like `SkyCoord` will be composed structures bringing together the reference frame (an instance of a `BaseCoordinateFrame` subclass) and the coordinate data (`Representation` objects).
+The end result of the implementation of this APE will be that coordinate frame classes 
+only hold information pertaining to the reference frame they represent and never actual 
+coordinate data in that reference frame. This is consistent with our mathematical 
+framework, the reference frame mediates how coordinate data is understood (e.g. distance 
+measures) or interacts (e.g. separation from other coordinates), but the coordinate data 
+itself is actually independent of that information. Classes like ``SkyCoord`` will be 
+composed structures bringing together the reference frame (an instance of a 
+``BaseCoordinateFrame`` subclass) and the coordinate data (``Representation`` objects).
 
 We illustrate this with the following pseudocode.
 
@@ -58,32 +122,45 @@ We illustrate this with the following pseudocode.
 
 Branches and pull requests
 --------------------------
-No direct progress on these changes has yet occurred. Discussion of these ideas has however arisen in multiple issues and pull requests, demonstrating the need for and utility of the proposed changes.
+No direct progress on these changes has yet occurred. Discussion of these ideas has 
+however arisen in multiple issues and pull requests, demonstrating the need for and 
+utility of the proposed changes.
 
-Several issues have been raised regarding topics such as confusion differentiating the use of `frame` and `SkyCoord` for data storage, and problems arising in other astropy subpackages when using frames that store data. For example:
+Several issues have been raised regarding topics such as confusion differentiating the 
+use of ``frame`` and ``SkyCoord`` for data storage, and problems arising in other astropy 
+subpackages when using frames that store data. For example:
 
 - *Comparing Frame with data and SkyCoord with same data raises exception*: `https://github.com/astropy/astropy/issues/13476`
 - *Add Frame objects without data to a Table*: `https://github.com/astropy/astropy/issues/16823`
 
-Additionally, multiple pull requests have factored out common code between frames and `SkyCoord`, showing that there is no proper separation of concern:
+Additionally, multiple pull requests have factored out common code between frames and 
+``SkyCoord``, showing that there is no proper separation of concern:
 
 - *Introduction of shared `CoordinateFrameInfo`*: `https://github.com/astropy/astropy/pull/16831`
-- *Introduction of `CoordinateSharedMethods`* (this was later removed and instead methods were duplicated): `https://github.com/astropy/astropy/pull/17016`
+- *Introduction of `CoordinateSharedMethods`* (this was later removed and instead methods 
+were duplicated): `https://github.com/astropy/astropy/pull/17016`
 
-Further, pull requests have added methods to make frames and `SkyCoord` even more similar, underscoring that frames *with* data should not be separate entities from `SkyCoord`:
+Further, pull requests have added methods to make frames and ``SkyCoord`` even more 
+similar, underscoring that frames *with* data should not be separate entities from 
+``SkyCoord``:
 
 - *Add .to_table() to frames*: `https://github.com/astropy/astropy/pull/17009`
 - *Add .frame attribute to frames*: `https://github.com/astropy/astropy/pull/16356`
 
 Implementation
 --------------
-The direct use of coordinate frames instead of `SkyCoord` is common. In particular ICRS objects are frequently created with data. Given the prevalent use, it is imperative to maintain backward compatibility and not break the API too quickly. Therefore, we propose implementing this APE through 3 steps (and substeps).
+The direct use of coordinate frames instead of ``SkyCoord`` is common. In particular 
+`ICRS`` objects are frequently created with data. Given the prevalent use, it is imperative 
+to maintain backward compatibility and not break the API too quickly. Therefore, we 
+propose implementing this APE through 3 steps (and substeps).
 
 1. Splitting the frame classes into two hierarchies: ones with and without data.
-2. Switching `SkyCoord` to use the data-less frame classes, and enabling automatic conversion of the with-data frames into `SkyCoord` objects.
+2. Switching ``SkyCoord`` to use the data-less frame classes, and enabling automatic 
+conversion of the with-data frames into ``SkyCoord`` objects.
 3. Deprecating the legacy with-data frame classes.
    1. Emitting warnings when instantiated.
-   2. Still warn, but return a `SkyCoord`, not an instance of its class type (by overriding __new__)
+   2. Still warn, but return a ``SkyCoord``, not an instance of its class type (by 
+   overriding ``__new__``)
    3. Remove.
 
 The 3 steps (at stage 3a) are illustrated in the following pseudocode:

--- a/APE26.rst
+++ b/APE26.rst
@@ -161,12 +161,12 @@ conversion of the with-data frames into ``SkyCoord`` objects.
 
 3. Deprecating the legacy with-data frame classes.
 
-   a. Emitting warnings when instantiated.
+   - Emitting warnings when instantiated.
 
-   b. Still warn, but return a ``SkyCoord``, not an instance of its class type (by 
+   - Still warn, but return a ``SkyCoord``, not an instance of its class type (by 
    overriding ``__new__``)
 
-   c. Remove.
+   - Remove.
 
 The 3 steps (at stage 3a) are illustrated in the following pseudocode:
 

--- a/APE26.rst
+++ b/APE26.rst
@@ -1,0 +1,139 @@
+Removing data storage (representations) from coordinate frames
+==============================================================
+
+Authors (alphabetical): Jeff Jennings, Adrian Price-Whelan, Nathaniel Starkman, Marten van Kerkwijk
+---------------------------------------------------------------------------------------------------
+
+:date-created: 2024 11 04
+:date-last-revised: 2024 11 04
+:date-accepted: 202x xx xx
+:type: Standard Track
+:status: Discussion
+
+Abstract
+--------
+Coordinate frames in astropy.coordinates currently store metadata used to construct the frame (i.e. for transforming between frames) and may also store coordinate *data* itself. This duplicates functionality with `SkyCoord`, which acts as a container for both coordinate data and reference frame information. We propose to change the frame classes such that they only store metadata and never coordinate data. This would make the implementation more modular, remove ambiguity for users from having nearly duplicate functionality with slightly different APIs, and better satisfy the principle of Separation of Concerns.
+
+Detailed description
+--------------------
+The coordinate frame classes (subclasses of `BaseCoordinateFrame`, e.g., `ICRS`, `Galactic`, `FK4`, etc.) are used to represent astronomical reference frames. These may also contain position, velocity, time, or other information about the reference frame relative to another reference frame, which is used to transform coordinates between the reference frames that exist in the `astropy.coordinates` ecosystem. For example, the `AltAz` frame class, which is used when referencing sky coordinates in altitude and azimuth, must contain a location on Earth and a time in order to transform to and from a fixed reference frame like the ICRS. In addition to reference frame information, these frame classes can **also** contain coordinate data (positions, velocities, or other differentials), which are stored internally using the `Representation` and `Differential` classes.
+
+The above reveals a problematic oddity with the coordinate frame implementation – an insufficient `separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`_. The coordinate frame class deals with two separate issues: the definition of the frame and the storage of coordinate data within that frame. Ideally the code would be more modularly structured, where the coordinate frame class **only** defines the reference frame. It would then be the purview of another class – `SkyCoord` – to bring these concerns together and to represent data (using `Representation` and `Differential` classes) in a given reference frame (using a `CoordinateFrame` class). As a demonstration of the current state of duplicated functionality, these two initializations effectively represent the same thing, but return different objects with similar but not identical APIs:
+
+.. code-block:: python
+
+    c1 = SkyCoord(1., 2., frame="icrs", units="deg")
+    c2 = ICRS(1. * u.deg, 2. * u.deg)
+
+We suggest the situation should instead be analogous to what is the case for units, which know how to transform from one to another, but are not concerned with how the values are stored (that belongs to `Quantity`). Translating to coordinates, units are like `CoordinateFrame`, the values are the coordinate data (`Representations`), and `Quantity` is like `SkyCoord`.
+
+Having both the frame classes as well as `SkyCoord` be able to store and handle data has resulted in a large amount of code duplication. Restructuring the `Frame` classes to remove data storage will allow for much more maintainable, de-duplicated code. It will also make it easier to contribute: if there is a problem one would like to solve in a given method, if one looks in `SkyCoord`, one will likely find that it does not exist, but instead is defined on `BaseCoordinateFrame` and gets dynamically called via `SkyCoord.__getattr__`. Indeed, the construction of `BaseCoordinateFrame` ends up complicating `SkyCoord`, which has to manage the coordinate data **through** the stored BaseCoordinateFrame.
+
+Another issue with the current implementation of coordinate frames is that the optional inclusion of coordinate data makes the reference frames “multi-modal”. This creates different usage modes (with and without data), each exhibiting different behavior. For instance, some methods such as `separation` work fine with frames with data, while doing this on coordinate frames without data results in an error. This kind of multi-modal structure is considered an anti-pattern because it forces any code interacting with the frame classes to handle both cases (checking `frame.has_data`), complicating the codebase unnecessarily.
+
+All the points discussed thus far – separation of concerns and code duplication – concern maintainers. However user experience is the more important consideration. In this arena too, separating frames from data storage has its advantages. Perhaps most importantly, documentation will be more obvious: the methods and attributes are defined on `SkyCoord`, and sphinx will know how to typeset those. It will also be easier: following the Zen of Python, there should be one clear way to do something. The present overlap leads to confusion where beginner users end up creating `BaseCoordinateFrame` objects such as `ICRS`, when the docs are clear that these are for more advanced users and that `SkyCoord` is to be preferred. The system will also be less fragile. For example, if users manipulate the internal workings of `SkyCoord` (which is discouraged but possible), the coordinate data can become decoupled from the caching that `SkyCoord` performs for speed.
+
+Finished Product
+----------------
+The end result of the implementation of this APE will be that coordinate frame classes only hold information pertaining to the reference frame they represent and never actual coordinate data in that reference frame. This is consistent with our mathematical framework, the reference frame mediates how coordinate data is understood (e.g. distance measures) or interacts (e.g. separation from other coordinates), but the coordinate data itself is actually independent of that information. Classes like `SkyCoord` will be composed structures bringing together the reference frame (an instance of a `BaseCoordinateFrame` subclass) and the coordinate data (`Representation` objects).
+
+We illustrate this with the following pseudocode.
+
+.. code-block:: python
+
+    @dataclass
+    class BaseCoordinateFrame:
+        ...
+
+    @dataclass
+    class FK5(BaseCoordinateFrame):
+        equinox: Time
+
+    class SkyCoord:
+        frame: BaseCoordinateFrame
+        data: Representation
+
+        def __init__(...):
+            ...
+
+Branches and pull requests
+--------------------------
+No direct progress on these changes has yet occurred. Discussion of these ideas has however arisen in multiple issues and pull requests, demonstrating the need for and utility of the proposed changes.
+
+Several issues have been raised regarding topics such as confusion differentiating the use of `frame` and `SkyCoord` for data storage, and problems arising in other astropy subpackages when using frames that store data. For example:
+
+- *Comparing Frame with data and SkyCoord with same data raises exception*: `https://github.com/astropy/astropy/issues/13476`
+- *Add Frame objects without data to a Table*: `https://github.com/astropy/astropy/issues/16823`
+
+Additionally, multiple pull requests have factored out common code between frames and `SkyCoord`, showing that there is no proper separation of concern:
+
+- *Introduction of shared `CoordinateFrameInfo`*: `https://github.com/astropy/astropy/pull/16831`
+- *Introduction of `CoordinateSharedMethods`* (this was later removed and instead methods were duplicated): `https://github.com/astropy/astropy/pull/17016`
+
+Further, pull requests have added methods to make frames and `SkyCoord` even more similar, underscoring that frames *with* data should not be separate entities from `SkyCoord`:
+
+- *Add .to_table() to frames*: `https://github.com/astropy/astropy/pull/17009`
+- *Add .frame attribute to frames*: `https://github.com/astropy/astropy/pull/16356`
+
+Implementation
+--------------
+The direct use of coordinate frames instead of `SkyCoord` is common. In particular ICRS objects are frequently created with data. Given the prevalent use, it is imperative to maintain backward compatibility and not break the API too quickly. Therefore, we propose implementing this APE through 3 steps (and substeps).
+
+1. Splitting the frame classes into two hierarchies: ones with and without data.
+2. Switching `SkyCoord` to use the data-less frame classes, and enabling automatic conversion of the with-data frames into `SkyCoord` objects.
+3. Deprecating the legacy with-data frame classes.
+   1. Emitting warnings when instantiated.
+   2. Still warn, but return a `SkyCoord`, not an instance of its class type (by overriding __new__)
+   3. Remove.
+
+The 3 steps (at stage 3a) are illustrated in the following pseudocode:
+
+.. code-block:: python
+
+    # === Reference Frame (no data) ===
+
+    class AbstractReferenceFrame:
+        ...
+
+        # Like `unit.to`
+        def transform_data_to(self, frame: AbstractReferenceFrame, data: Representation) -> Representation:
+            """Used by `AbstractCoordinate` for transformation."""
+            ...
+
+    class ICRSFrame(AbstractReferenceFrame):
+        ...
+
+    class FK5Frame(AbstractReferenceFrame):
+        equinox: Time
+
+    # === Coordinates (data + frame) ===
+
+    class AbstractCoordinate:
+        """Base class for data in a reference frame."""
+        ...
+
+    class SkyCoord(AbstractCoordinate):
+        frame: AbstractReferenceFrame
+        data: Representation
+
+        def __init__(...):
+            # If the frame is a `AbstractLegacyCoordinate` then it is
+            # split into a `AbstractReferenceFrame` and `Representation`
+            ...
+
+    # === Legacy Coordinate Classes ===
+
+    class AbstractLegacyCoordinate(AbstractCoordinate):
+
+        def __new__(self):
+            warnings.warn("Please use SkyCoord")
+
+        @abstractpropery # implemented on subclasses
+        def frame(self) -> AbstractReferenceFrame:
+            ...
+
+    class ICRS(AbstractLegacyCoordinate, ICRSFrame):
+        ...
+
+    class FK5(AbstractLegacyCoordinate, FK5Frame):
+        ...

--- a/APE26.rst
+++ b/APE26.rst
@@ -163,8 +163,7 @@ conversion of the with-data frames into ``SkyCoord`` objects.
 
    - Emitting warnings when instantiated.
 
-   - Still warn, but return a ``SkyCoord``, not an instance of its class type (by 
-   overriding ``__new__``)
+   - Still warn, but return a ``SkyCoord``, not an instance of its class type (by overriding ``__new__``)
 
    - Remove.
 

--- a/APE26.rst
+++ b/APE26.rst
@@ -5,7 +5,7 @@ Authors (alphabetical): Jeff Jennings, Adrian Price-Whelan, Nathaniel Starkman, 
 ---------------------------------------------------------------------------------------------------
 
 :date-created: 2024 11 04
-:date-last-revised: 2025 02 10
+:date-last-revised: 2025 04 28
 :date-accepted: 202x xx xx
 :type: Standard Track
 :status: Discussion

--- a/APE26.rst
+++ b/APE26.rst
@@ -142,7 +142,7 @@ Coordinate frame classes only hold information pertaining to
 the reference frame they represent and never actual coordinate
 data in that reference frame. This is consistent with our
 mathematical framework, the reference frame mediates how
-coordinate data is understood (e.g. distance measures) or
+coordinate data is understood (e.g., distance measures) or
 interacts (e.g. separation from other coordinates), but the
 coordinate data itself is actually independent of that
 information.

--- a/APE26.rst
+++ b/APE26.rst
@@ -119,7 +119,7 @@ most importantly, documentation will be more obvious: the methods
 and attributes are defined on ``SkyCoord`` (and ``Coordinate``)
 proper, so `Sphinx <https://www.sphinx-doc.org/>`_ will know how to typeset those, while type
 checkers can help users in finding and using them properly. It
-will also be easier: following the Zen of Python, there should be
+will also be easier: following the `Zen of Python <https://peps.python.org/pep-0020/>`_, "There should be
 one clear way to do something. The present overlap leads to
 confusion wherein beginner users end up creating
 ``BaseCoordinateFrame`` objects such as ``ICRS``, when the docs

--- a/APE26.rst
+++ b/APE26.rst
@@ -78,9 +78,12 @@ are not concerned with how the values are stored (that belongs to
 
 Having both the frame classes as well as ``SkyCoord`` be able to
 store and handle data has resulted in a large amount of code
-duplication (not just in the code proper, but also in the tests,
-leading to missed combinations). Restructuring the ``Frame``
-classes to remove data storage will allow for much more
+duplication. It has also required duplicated or even quadrupled 
+tests, in order to test both ``BaseCoordinateFrame`` and 
+``SkyCoord`` methods with both ``BaseCoordinateFrame`` and 
+``SkyCoord`` arguments - where the tests have not caught every 
+combination, problems have gone unnoticed. Restructuring the 
+``frame`` classes to remove data storage will allow for much more
 maintainable, de-duplicated code. It will also make it easier to
 contribute: if there is a problem one would like to solve in a
 given method, if one looks in ``SkyCoord``, one will likely find

--- a/APE26.rst
+++ b/APE26.rst
@@ -5,21 +5,23 @@ Authors (alphabetical): Jeff Jennings, Adrian Price-Whelan, Nathaniel Starkman, 
 ---------------------------------------------------------------------------------------------------
 
 :date-created: 2024 11 04
-:date-last-revised: 2024 11 04
+:date-last-revised: 2025 02 10
 :date-accepted: 202x xx xx
 :type: Standard Track
 :status: Discussion
 
 Abstract
 --------
-Coordinate frames in astropy.coordinates currently store metadata used to construct the
+Following the rationale presented in `APE 5 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_,
+coordinate frames in astropy.coordinates currently store metadata used to construct the
 frame (i.e. for transforming between frames) and may also store coordinate *data* itself.
 This duplicates functionality with ``SkyCoord``, which acts as a container for both
 coordinate data and reference frame information. We propose to change the frame classes
-such that they only store metadata and never coordinate data. This would make the
-implementation more modular, remove ambiguity for users from having nearly duplicate
-functionality with slightly different APIs, and better satisfy the principle of
-Separation of Concerns.
+such that they only store metadata and never coordinate data, superseding this aspect 
+of the implementation in `APE 5 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_. 
+This would make the implementation more modular, remove ambiguity for users from having 
+nearly duplicate functionality with slightly different APIs, and better satisfy the 
+principle of Separation of Concerns.
 
 Detailed description
 --------------------
@@ -35,7 +37,9 @@ frame classes can **also** contain coordinate data (positions, velocities, or ot
 differentials), which are stored internally using the ``Representation`` and
 ``Differential`` classes.
 
-The above reveals a problematic oddity with the coordinate frame implementation – an
+The above reflects a design choice in the coordinate frame implementation in 
+`APE 5 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_ that, following 
+several years of use, we have learned from and think best to revise. We now view it as an 
 insufficient `separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`_.
 The coordinate frame class deals with two separate issues: the definition of the frame
 and the storage of coordinate data within that frame. Ideally the code would be more
@@ -73,10 +77,13 @@ Another issue with the current implementation of coordinate frames is that the o
 inclusion of coordinate data makes the reference frames “multi-modal”. This creates
 different usage modes (with and without data), each exhibiting different behavior. For
 instance, some methods such as ``separation`` work fine with frames with data, while
-doing this on coordinate frames without data results in an error. This kind of
-multi-modal structure is considered an anti-pattern because it forces any code
-interacting with the frame classes to handle both cases (checking ``frame.has_data``),
-complicating the codebase unnecessarily.
+doing this on coordinate frames without data results in an error. While this multi-modal 
+structure as motivated in `APE 5 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_ 
+can be seen as a benefit for interpretability of the logic, we also now see it from the
+perspective of an anti-pattern. It forces any code interacting with the frame classes 
+to handle both cases (checking ``frame.has_data``), complicating the codebase. We thus 
+find it worthwhile to separate coordinate data from reference frames at the possible 
+expense of ease of understanding for some developers.
 
 All the points discussed thus far – separation of concerns and code duplication –
 concern maintainers. However user experience is the more important consideration. In
@@ -85,12 +92,12 @@ importantly, documentation will be more obvious: the methods and attributes are 
 on ``SkyCoord`` proper, so sphinx will know how to typeset those, while type checkers
 can help users in finding and using them propertly. It will also be easier:
 following the Zen of Python, there should be one clear way to do something. The present
-overlap leads to confusion where beginner users end up creating ``BaseCoordinateFrame``
+overlap leads to confusion wherein beginner users end up creating ``BaseCoordinateFrame``
 objects such as ``ICRS``, when the docs are clear that these are for more advanced users
-and that ``SkyCoord`` is to be preferred. The system will also be less fragile. For
-example, if users manipulate the internal workings of ``SkyCoord`` (which is discouraged
-but possible), the coordinate data can become decoupled from the caching that ``SkyCoord``
-performs for speed.
+and that ``SkyCoord`` is to be preferred.
+The system will also be less fragile. For example, if users manipulate the 
+internal workings of ``SkyCoord`` (which is discouraged but possible), the coordinate 
+data can become decoupled from the caching that ``SkyCoord`` performs for speed.
 
 Finished Product
 ----------------

--- a/APE26.rst
+++ b/APE26.rst
@@ -198,7 +198,12 @@ The third step (at stage 3a) is illustrated in the following pseudocode:
         data: BaseRepresentation
         ...
 
+class Coordinate(BaseCoordinate):
+    """Data in a reference frame."""
+    pass
+
     class SkyCoord(BaseCoordinate):
+         """Data in a reference frame, batteries included."""
 
         def __init__(...):
             # If the frame is a LegacyBaseCoordinateFrame then it is

--- a/APE26.rst
+++ b/APE26.rst
@@ -120,7 +120,7 @@ and attributes are defined on ``SkyCoord`` (and ``Coordinate``)
 proper, so `Sphinx <https://www.sphinx-doc.org/>`_ will know how to typeset those, while type
 checkers can help users in finding and using them properly. It
 will also be easier: following the `Zen of Python <https://peps.python.org/pep-0020/>`_, "There should be
-one clear way to do something. The present overlap leads to
+one-- and preferably only one --obvious way to do it." The present overlap leads to
 confusion wherein beginner users end up creating
 ``BaseCoordinateFrame`` objects such as ``ICRS``, when the docs
 are clear that these are for more advanced users and that

--- a/APE26.rst
+++ b/APE26.rst
@@ -130,21 +130,21 @@ Several issues have been raised regarding topics such as confusion differentiati
 use of ``frame`` and ``SkyCoord`` for data storage, and problems arising in other astropy 
 subpackages when using frames that store data. For example:
 
-- `Comparing Frame with data and SkyCoord with same data raises exception <https://github.com/astropy/astropy/issues/13476>`_
-- `Add Frame objects without data to a Table <https://github.com/astropy/astropy/issues/16823>`_
+- `Comparing Frame with data and SkyCoord with same data raises exception #13476 <https://github.com/astropy/astropy/issues/13476>`_
+- `Add Frame objects without data to a Table #16823 <https://github.com/astropy/astropy/issues/16823>`_
 
 Additionally, multiple pull requests have factored out common code between frames and 
 ``SkyCoord``, showing that there is no proper separation of concern:
 
-- `Introduction of shared CoordinateFrameInfo <https://github.com/astropy/astropy/pull/16831>`_
-- `Introduction of CoordinateSharedMethods <https://github.com/astropy/astropy/pull/17016>`_ (this was later removed and instead methods were duplicated)
+- `Allow BaseCoordinateFrames to be stored in tables (by giving them .info) #16831 <https://github.com/astropy/astropy/pull/16831>`_
+- `Masked frames and SkyCoord #17106 <https://github.com/astropy/astropy/pull/17016>`_ (this was later removed and instead methods were duplicated)
 
 Further, pull requests have added methods to make frames and ``SkyCoord`` even more 
 similar, underscoring that frames *with* data should not be separate entities from 
 ``SkyCoord``:
 
-- `Add .to_table() to frames <https://github.com/astropy/astropy/pull/17009>`_
-- `Add .frame attribute to frames <https://github.com/astropy/astropy/pull/16356>`_
+- `Implement BaseCoordinateFrame.to_table() #17009 <https://github.com/astropy/astropy/pull/17009>`_
+- `Implement BaseCoordinateFrame.frame property #16356 <https://github.com/astropy/astropy/pull/16356>`_
 
 Implementation
 --------------

--- a/APE26.rst
+++ b/APE26.rst
@@ -219,5 +219,5 @@ The third step (at stage 3a) is illustrated in the following pseudocode:
     class ICRS(BaseCoordinateFrame, ICRSFrame):
         ...
 
-    class FK5(LegacyCoordinateFrame, FK5Frame):
+    class FK5(BaseCoordinateFrame, FK5Frame):
         ...

--- a/APE26.rst
+++ b/APE26.rst
@@ -87,9 +87,9 @@ combination, problems have gone unnoticed. Restructuring the
 maintainable, de-duplicated code. It will also make it easier to
 contribute: if there is a problem one would like to solve in a
 given method, if one looks in ``SkyCoord``, one will likely find
-that it does not exist, but instead is defined on
-``BaseCoordinateFrame`` and gets dynamically called via
-``SkyCoord.__getattr__``. Indeed, the construction of
+that it does not exist, and might struggle to find that instead 
+it is defined on ``BaseCoordinateFrame`` and gets dynamically 
+called via  ``SkyCoord.__getattr__``. Indeed, the construction of
 ``BaseCoordinateFrame`` ends up complicating ``SkyCoord``, which
 has to manage the coordinate data **through** the stored
 ``BaseCoordinateFrame``.

--- a/APE26.rst
+++ b/APE26.rst
@@ -143,7 +143,7 @@ the reference frame they represent and never actual coordinate
 data in that reference frame. This is consistent with our
 mathematical framework, the reference frame mediates how
 coordinate data is understood (e.g., distance measures) or
-interacts (e.g. separation from other coordinates), but the
+interacts (e.g., separation from other coordinates), but the
 coordinate data itself is actually independent of that
 information.
 

--- a/APE26.rst
+++ b/APE26.rst
@@ -125,7 +125,7 @@ will also be easier: following the
 be one-- and preferably only one --obvious way to do it." The 
 present overlap leads to
 confusion wherein beginner users end up creating
-``BaseCoordinateFrame`` objects such as ``ICRS``, when the docs
+``BaseCoordinateFrame`` instances, when the docs
 are clear that these are for more advanced users and that
 ``SkyCoord`` is to be preferred. The system will also be less
 fragile. For example, if users manipulate the internal workings

--- a/APE26.rst
+++ b/APE26.rst
@@ -254,7 +254,7 @@ substeps).
    enabling automatic conversion of the with-data frames into 
    ``SkyCoord`` objects.
 
-4. Deprecating the legacy with-data frame classes.
+4. Deprecating the legacy with-data frame classes, and eventually removing them after a deprecation period that adheres to `APE 2 <https://github.com/astropy/astropy-APEs/blob/main/APE2.rst>`_.
 
    - Emitting warnings when instantiated.
 

--- a/APE26.rst
+++ b/APE26.rst
@@ -198,9 +198,9 @@ The third step (at stage 3a) is illustrated in the following pseudocode:
         data: BaseRepresentation
         ...
 
-class Coordinate(BaseCoordinate):
-    """Data in a reference frame."""
-    pass
+    class Coordinate(BaseCoordinate):
+        """Data in a reference frame."""
+        pass
 
     class SkyCoord(BaseCoordinate):
          """Data in a reference frame, batteries included."""

--- a/APE26.rst
+++ b/APE26.rst
@@ -12,39 +12,39 @@ Authors (alphabetical): Jeff Jennings, Adrian Price-Whelan, Nathaniel Starkman, 
 
 Abstract
 --------
-Coordinate frames in astropy.coordinates currently store metadata used to construct the 
-frame (i.e. for transforming between frames) and may also store coordinate *data* itself. 
-This duplicates functionality with ``SkyCoord``, which acts as a container for both 
-coordinate data and reference frame information. We propose to change the frame classes 
-such that they only store metadata and never coordinate data. This would make the 
-implementation more modular, remove ambiguity for users from having nearly duplicate 
-functionality with slightly different APIs, and better satisfy the principle of 
+Coordinate frames in astropy.coordinates currently store metadata used to construct the
+frame (i.e. for transforming between frames) and may also store coordinate *data* itself.
+This duplicates functionality with ``SkyCoord``, which acts as a container for both
+coordinate data and reference frame information. We propose to change the frame classes
+such that they only store metadata and never coordinate data. This would make the
+implementation more modular, remove ambiguity for users from having nearly duplicate
+functionality with slightly different APIs, and better satisfy the principle of
 Separation of Concerns.
 
 Detailed description
 --------------------
-The coordinate frame classes (subclasses of ``BaseCoordinateFrame``, e.g., ``ICRS``, 
-``Galactic``, ``FK4``, etc.) are used to represent astronomical reference frames. These 
-may also contain position, velocity, time, or other information about the reference frame 
-relative to another reference frame, which is used to transform coordinates between the 
-reference frames that exist in the ``astropy.coordinates`` ecosystem. For example, the 
-``AltAz`` frame class, which is used when referencing sky coordinates in altitude and 
-azimuth, must contain a location on Earth and a time in order to transform to and from a 
-fixed reference frame like the ICRS. In addition to reference frame information, these 
-frame classes can **also** contain coordinate data (positions, velocities, or other 
-differentials), which are stored internally using the ``Representation`` and 
+The coordinate frame classes (subclasses of ``BaseCoordinateFrame``, e.g., ``ICRS``,
+``Galactic``, ``FK4``, etc.) are used to represent astronomical reference frames. These
+may also contain position, velocity, time, or other information about the reference frame
+relative to another reference frame, which is used to transform coordinates between the
+reference frames that exist in the ``astropy.coordinates`` ecosystem. For example, the
+``AltAz`` frame class, which is used when referencing sky coordinates in altitude and
+azimuth, must contain a location on Earth and a time in order to transform to and from a
+fixed reference frame like the ICRS. In addition to reference frame information, these
+frame classes can **also** contain coordinate data (positions, velocities, or other
+differentials), which are stored internally using the ``Representation`` and
 ``Differential`` classes.
 
-The above reveals a problematic oddity with the coordinate frame implementation – an 
-insufficient `separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`_. 
-The coordinate frame class deals with two separate issues: the definition of the frame 
-and the storage of coordinate data within that frame. Ideally the code would be more 
-modularly structured, where the coordinate frame class **only** defines the reference 
-frame. It would then be the purview of another class – ``SkyCoord`` – to bring these 
-concerns together and to represent data (using ``Representation`` and ``Differential`` 
-classes) in a given reference frame (using a ``CoordinateFrame`` class). As a demonstration 
-of the current state of duplicated functionality, these two initializations effectively 
-represent the same thing, but return different objects with similar but not identical 
+The above reveals a problematic oddity with the coordinate frame implementation – an
+insufficient `separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`_.
+The coordinate frame class deals with two separate issues: the definition of the frame
+and the storage of coordinate data within that frame. Ideally the code would be more
+modularly structured, where the coordinate frame class **only** defines the reference
+frame. It would then be the purview of another class – ``SkyCoord`` – to bring these
+concerns together and to represent data (using ``Representation`` and ``Differential``
+classes) in a given reference frame (using a ``CoordinateFrame`` class). As a demonstration
+of the current state of duplicated functionality, these two initializations effectively
+represent the same thing, but return different objects with similar but not identical
 APIs:
 
 .. code-block:: python
@@ -52,53 +52,55 @@ APIs:
     c1 = SkyCoord(1., 2., frame="icrs", units="deg")
     c2 = ICRS(1. * u.deg, 2. * u.deg)
 
-We suggest the situation should instead be analogous to what is the case for units, 
-which know how to transform from one to another, but are not concerned with how the 
-values are stored (that belongs to ``Quantity``). Translating to coordinates, units are 
-like ``CoordinateFrame``, the values are the coordinate data (``Representations``), and 
+We suggest the situation should instead be analogous to what is the case for units,
+which know how to transform from one to another, but are not concerned with how the
+values are stored (that belongs to ``Quantity``). Translating to coordinates, units are
+like ``CoordinateFrame``, the values are the coordinate data (``Representations``), and
 ``Quantity`` is like ``SkyCoord``.
 
-Having both the frame classes as well as ``SkyCoord`` be able to store and handle data 
-has resulted in a large amount of code duplication. Restructuring the ``Frame`` classes 
-to remove data storage will allow for much more maintainable, de-duplicated code. It 
-will also make it easier to contribute: if there is a problem one would like to solve 
-in a given method, if one looks in ``SkyCoord``, one will likely find that it does not 
-exist, but instead is defined on ``BaseCoordinateFrame`` and gets dynamically called via 
-``SkyCoord.__getattr__``. Indeed, the construction of ``BaseCoordinateFrame`` ends up 
-complicating ``SkyCoord``, which has to manage the coordinate data **through** the stored 
+Having both the frame classes as well as ``SkyCoord`` be able to store and handle data
+has resulted in a large amount of code duplication (not just in the code proper, but
+also in the tests, leading to missed combinations). Restructuring the ``Frame`` classes
+to remove data storage will allow for much more maintainable, de-duplicated code. It
+will also make it easier to contribute: if there is a problem one would like to solve
+in a given method, if one looks in ``SkyCoord``, one will likely find that it does not
+exist, but instead is defined on ``BaseCoordinateFrame`` and gets dynamically called via
+``SkyCoord.__getattr__``. Indeed, the construction of ``BaseCoordinateFrame`` ends up
+complicating ``SkyCoord``, which has to manage the coordinate data **through** the stored
 ``BaseCoordinateFrame``.
 
-Another issue with the current implementation of coordinate frames is that the optional 
-inclusion of coordinate data makes the reference frames “multi-modal”. This creates 
-different usage modes (with and without data), each exhibiting different behavior. For 
-instance, some methods such as ``separation`` work fine with frames with data, while 
-doing this on coordinate frames without data results in an error. This kind of 
-multi-modal structure is considered an anti-pattern because it forces any code 
-interacting with the frame classes to handle both cases (checking ``frame.has_data``), 
+Another issue with the current implementation of coordinate frames is that the optional
+inclusion of coordinate data makes the reference frames “multi-modal”. This creates
+different usage modes (with and without data), each exhibiting different behavior. For
+instance, some methods such as ``separation`` work fine with frames with data, while
+doing this on coordinate frames without data results in an error. This kind of
+multi-modal structure is considered an anti-pattern because it forces any code
+interacting with the frame classes to handle both cases (checking ``frame.has_data``),
 complicating the codebase unnecessarily.
 
-All the points discussed thus far – separation of concerns and code duplication – 
-concern maintainers. However user experience is the more important consideration. In 
-this arena too, separating frames from data storage has its advantages. Perhaps most 
-importantly, documentation will be more obvious: the methods and attributes are defined 
-on ``SkyCoord``, and sphinx will know how to typeset those. It will also be easier: 
-following the Zen of Python, there should be one clear way to do something. The present 
-overlap leads to confusion where beginner users end up creating ``BaseCoordinateFrame`` 
-objects such as ``ICRS``, when the docs are clear that these are for more advanced users 
-and that ``SkyCoord`` is to be preferred. The system will also be less fragile. For 
-example, if users manipulate the internal workings of ``SkyCoord`` (which is discouraged 
-but possible), the coordinate data can become decoupled from the caching that ``SkyCoord`` 
+All the points discussed thus far – separation of concerns and code duplication –
+concern maintainers. However user experience is the more important consideration. In
+this arena too, separating frames from data storage has its advantages. Perhaps most
+importantly, documentation will be more obvious: the methods and attributes are defined
+on ``SkyCoord`` proper, so sphinx will know how to typeset those, while type checkers
+can help users in finding and using them propertly. It will also be easier:
+following the Zen of Python, there should be one clear way to do something. The present
+overlap leads to confusion where beginner users end up creating ``BaseCoordinateFrame``
+objects such as ``ICRS``, when the docs are clear that these are for more advanced users
+and that ``SkyCoord`` is to be preferred. The system will also be less fragile. For
+example, if users manipulate the internal workings of ``SkyCoord`` (which is discouraged
+but possible), the coordinate data can become decoupled from the caching that ``SkyCoord``
 performs for speed.
 
 Finished Product
 ----------------
-The end result of the implementation of this APE will be that coordinate frame classes 
-only hold information pertaining to the reference frame they represent and never actual 
-coordinate data in that reference frame. This is consistent with our mathematical 
-framework, the reference frame mediates how coordinate data is understood (e.g. distance 
-measures) or interacts (e.g. separation from other coordinates), but the coordinate data 
-itself is actually independent of that information. Classes like ``SkyCoord`` will be 
-composed structures bringing together the reference frame (an instance of a 
+The end result of the implementation of this APE will be that coordinate frame classes
+only hold information pertaining to the reference frame they represent and never actual
+coordinate data in that reference frame. This is consistent with our mathematical
+framework, the reference frame mediates how coordinate data is understood (e.g. distance
+measures) or interacts (e.g. separation from other coordinates), but the coordinate data
+itself is actually independent of that information. Classes like ``SkyCoord`` will be
+composed structures bringing together the reference frame (an instance of a
 ``BaseCoordinateFrame`` subclass) and the coordinate data (``Representation`` objects).
 
 We illustrate this with the following pseudocode.
@@ -122,25 +124,25 @@ We illustrate this with the following pseudocode.
 
 Branches and pull requests
 --------------------------
-No direct progress on these changes has yet occurred. Discussion of these ideas has 
-however arisen in multiple issues and pull requests, demonstrating the need for and 
+No direct progress on these changes has yet occurred. Discussion of these ideas has
+however arisen in multiple issues and pull requests, demonstrating the need for and
 utility of the proposed changes.
 
-Several issues have been raised regarding topics such as confusion differentiating the 
-use of ``frame`` and ``SkyCoord`` for data storage, and problems arising in other astropy 
+Several issues have been raised regarding topics such as confusion differentiating the
+use of ``frame`` and ``SkyCoord`` for data storage, and problems arising in other astropy
 subpackages when using frames that store data. For example:
 
 - `Comparing Frame with data and SkyCoord with same data raises exception #13476 <https://github.com/astropy/astropy/issues/13476>`_
 - `Add Frame objects without data to a Table #16823 <https://github.com/astropy/astropy/issues/16823>`_
 
-Additionally, multiple pull requests have factored out common code between frames and 
+Additionally, multiple pull requests have factored out common code between frames and
 ``SkyCoord``, showing that there is no proper separation of concern:
 
 - `Allow BaseCoordinateFrames to be stored in tables (by giving them .info) #16831 <https://github.com/astropy/astropy/pull/16831>`_
 - `Masked frames and SkyCoord #17106 <https://github.com/astropy/astropy/pull/17016>`_ (this was later removed and instead methods were duplicated)
 
-Further, pull requests have added methods to make frames and ``SkyCoord`` even more 
-similar, underscoring that frames *with* data should not be separate entities from 
+Further, pull requests have added methods to make frames and ``SkyCoord`` even more
+similar, underscoring that frames *with* data should not be separate entities from
 ``SkyCoord``:
 
 - `Implement BaseCoordinateFrame.to_table() #17009 <https://github.com/astropy/astropy/pull/17009>`_
@@ -148,14 +150,14 @@ similar, underscoring that frames *with* data should not be separate entities fr
 
 Implementation
 --------------
-The direct use of coordinate frames instead of ``SkyCoord`` is common. In particular 
-``ICRS`` objects are frequently created with data. Given the prevalent use, it is imperative 
-to maintain backward compatibility and not break the API too quickly. Therefore, we 
+The direct use of coordinate frames instead of ``SkyCoord`` is common. In particular
+``ICRS`` objects are frequently created with data. Given the prevalent use, it is imperative
+to maintain backward compatibility and not break the API too quickly. Therefore, we
 propose implementing this APE through 3 steps (and substeps).
 
 1. Splitting the frame classes into two hierarchies: ones with and without data.
 
-2. Switching ``SkyCoord`` to use the data-less frame classes, and enabling automatic 
+2. Switching ``SkyCoord`` to use the data-less frame classes, and enabling automatic
 conversion of the with-data frames into ``SkyCoord`` objects.
 
 3. Deprecating the legacy with-data frame classes.

--- a/APE26.rst
+++ b/APE26.rst
@@ -40,9 +40,9 @@ insufficient `separation of concerns <https://en.wikipedia.org/wiki/Separation_o
 The coordinate frame class deals with two separate issues: the definition of the frame 
 and the storage of coordinate data within that frame. Ideally the code would be more 
 modularly structured, where the coordinate frame class **only** defines the reference 
-frame. It would then be the purview of another class – `SkyCoord` – to bring these 
-concerns together and to represent data (using `Representation` and `Differential` 
-classes) in a given reference frame (using a `CoordinateFrame` class). As a demonstration 
+frame. It would then be the purview of another class – ``SkyCoord`` – to bring these 
+concerns together and to represent data (using ``Representation`` and ``Differential`` 
+classes) in a given reference frame (using a ``CoordinateFrame`` class). As a demonstration 
 of the current state of duplicated functionality, these two initializations effectively 
 represent the same thing, but return different objects with similar but not identical 
 APIs:
@@ -130,27 +130,27 @@ Several issues have been raised regarding topics such as confusion differentiati
 use of ``frame`` and ``SkyCoord`` for data storage, and problems arising in other astropy 
 subpackages when using frames that store data. For example:
 
-- *Comparing Frame with data and SkyCoord with same data raises exception*: `https://github.com/astropy/astropy/issues/13476`
-- *Add Frame objects without data to a Table*: `https://github.com/astropy/astropy/issues/16823`
+- `Comparing Frame with data and SkyCoord with same data raises exception <https://github.com/astropy/astropy/issues/13476>`_
+- `Add Frame objects without data to a Table <https://github.com/astropy/astropy/issues/16823>`_
 
 Additionally, multiple pull requests have factored out common code between frames and 
 ``SkyCoord``, showing that there is no proper separation of concern:
 
-- *Introduction of shared `CoordinateFrameInfo`*: `https://github.com/astropy/astropy/pull/16831`
-- *Introduction of `CoordinateSharedMethods`* (this was later removed and instead methods 
-were duplicated): `https://github.com/astropy/astropy/pull/17016`
+- `Introduction of shared CoordinateFrameInfo <https://github.com/astropy/astropy/pull/16831>`_
+- `Introduction of CoordinateSharedMethods <https://github.com/astropy/astropy/pull/17016>`_ (this was later removed and instead methods 
+were duplicated)
 
 Further, pull requests have added methods to make frames and ``SkyCoord`` even more 
 similar, underscoring that frames *with* data should not be separate entities from 
 ``SkyCoord``:
 
-- *Add .to_table() to frames*: `https://github.com/astropy/astropy/pull/17009`
-- *Add .frame attribute to frames*: `https://github.com/astropy/astropy/pull/16356`
+- `Add .to_table() to frames <https://github.com/astropy/astropy/pull/17009>`_
+- `Add .frame attribute to frames <https://github.com/astropy/astropy/pull/16356>`_
 
 Implementation
 --------------
 The direct use of coordinate frames instead of ``SkyCoord`` is common. In particular 
-`ICRS`` objects are frequently created with data. Given the prevalent use, it is imperative 
+``ICRS`` objects are frequently created with data. Given the prevalent use, it is imperative 
 to maintain backward compatibility and not break the API too quickly. Therefore, we 
 propose implementing this APE through 3 steps (and substeps).
 

--- a/APE26.rst
+++ b/APE26.rst
@@ -131,11 +131,9 @@ confusion wherein beginner users end up creating
 ``BaseCoordinateFrame`` instances, when the docs
 are clear that these are for more advanced users and that
 ``SkyCoord`` is to be preferred. The system will also be less
-fragile. For example, if users manipulate the internal workings
-of ``SkyCoord`` (which is discouraged but possible), the
-coordinate data can become decoupled from the caching that
-``SkyCoord`` performs for speed. With these proposed changes
-users will have a more clear, introspectable, and robust system.
+fragile; with these proposed changes, users - and importantly 
+downstream developers who subclass ``SkyCoord`` - will have a 
+more clear, introspectable, and robust system.
 
 Finished Product
 ----------------

--- a/APE26.rst
+++ b/APE26.rst
@@ -216,7 +216,7 @@ The third step (at stage 3a) is illustrated in the following pseudocode:
         def frame(self) -> BaseFrame:
             ...
 
-    class ICRS(LegacyCoordinateFrame, ICRSFrame):
+    class ICRS(BaseCoordinateFrame, ICRSFrame):
         ...
 
     class FK5(LegacyCoordinateFrame, FK5Frame):

--- a/APE26.rst
+++ b/APE26.rst
@@ -137,8 +137,7 @@ Additionally, multiple pull requests have factored out common code between frame
 ``SkyCoord``, showing that there is no proper separation of concern:
 
 - `Introduction of shared CoordinateFrameInfo <https://github.com/astropy/astropy/pull/16831>`_
-- `Introduction of CoordinateSharedMethods <https://github.com/astropy/astropy/pull/17016>`_ (this was later removed and instead methods 
-were duplicated)
+- `Introduction of CoordinateSharedMethods <https://github.com/astropy/astropy/pull/17016>`_ (this was later removed and instead methods were duplicated)
 
 Further, pull requests have added methods to make frames and ``SkyCoord`` even more 
 similar, underscoring that frames *with* data should not be separate entities from 

--- a/APE26.rst
+++ b/APE26.rst
@@ -118,7 +118,7 @@ Classes like ``SkyCoord`` will be composed structures bringing together the
 reference frame (an instance of a ``BaseFrame`` subclass) and the coordinate
 data (``BaseRepresentation`` objects). We also introduce a new class,
 ``Coordinate``, which is akin to ``SkyCoord`` (containing both frame and data),
-but without extra features like caching and flexible input parsing. In this way
+but without extra features like keeping frame attributes not associated with the current frame, caching and flexible input parsing. In this way
 ``Coordinate`` operates very similarly to the current ``BaseCoordinateFrame``
 objects when they have data, and is meant to be their direct replacement in the
 new framework as well as a more lightweight and performant alternative to
@@ -195,8 +195,9 @@ propose implementing this APE through 4 steps (and substeps).
 1. Splitting the frame classes into two hierarchies: ones with and without data, with
 the data-less ones getting new names.
 
-2. Adding a new ``Coordinate`` class that is similar to ``SkyCoord``, but
-   without extra features like caching and flexible input parsing. It will only
+2. Adding a new ``Coordinate`` class that is similar to ``SkyCoord``, but which
+   does not keep any frame attributes not in the current frame, and does not
+   have extra features like caching and flexible input parsing. It will only
    accept data-less frame classes.
 
 3. Switching ``SkyCoord`` to use the data-less frame classes, and enabling automatic

--- a/APE26.rst
+++ b/APE26.rst
@@ -25,7 +25,8 @@ in `APE 5 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_.
 This would make the implementation more modular and performant, 
 remove ambiguity for users from having nearly duplicate functionality 
 with slightly different APIs, and better satisfy the principle of 
-Separation of Concerns.
+`Separation of Concerns
+<https://en.wikipedia.org/wiki/Separation_of_concerns>`_.
 
 Detailed description
 --------------------
@@ -49,8 +50,7 @@ implementation in `APE 5
 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_ 
 that, following several years of use, we have learned from and 
 think best to revise. We now view it as an insufficient 
-`separation of concerns 
-<https://en.wikipedia.org/wiki/Separation_of_concerns>`_. The 
+separation of concerns. The 
 coordinate frame class deals with two separate issues: the 
 definition of the frame and the storage of coordinate data within 
 that frame. Ideally the code would be more modularly structured, 

--- a/APE26.rst
+++ b/APE26.rst
@@ -160,11 +160,12 @@ propose implementing this APE through 3 steps (and substeps).
 conversion of the with-data frames into ``SkyCoord`` objects.
 
 3. Deprecating the legacy with-data frame classes.
+
    a. Emitting warnings when instantiated.
 
    b. Still warn, but return a ``SkyCoord``, not an instance of its class type (by 
    overriding ``__new__``)
-   
+
    c. Remove.
 
 The 3 steps (at stage 3a) are illustrated in the following pseudocode:

--- a/APE26.rst
+++ b/APE26.rst
@@ -39,7 +39,7 @@ coordinates between the reference frames that exist in the
 ``astropy.coordinates`` ecosystem. For example, the ``AltAz`` frame 
 class, which is used when referencing sky coordinates in altitude 
 and azimuth, must contain a location on Earth and a time in order 
-to transform to and from a fixed reference frame like the ICRS. In 
+to transform to and from an inertial reference frame like the ICRS. In 
 addition to reference frame information, these frame classes can 
 **also** contain coordinate data (positions, velocities, or other 
 differentials), which are stored internally using the 

--- a/APE26.rst
+++ b/APE26.rst
@@ -155,13 +155,17 @@ to maintain backward compatibility and not break the API too quickly. Therefore,
 propose implementing this APE through 3 steps (and substeps).
 
 1. Splitting the frame classes into two hierarchies: ones with and without data.
+
 2. Switching ``SkyCoord`` to use the data-less frame classes, and enabling automatic 
 conversion of the with-data frames into ``SkyCoord`` objects.
+
 3. Deprecating the legacy with-data frame classes.
-   1. Emitting warnings when instantiated.
-   2. Still warn, but return a ``SkyCoord``, not an instance of its class type (by 
+   a. Emitting warnings when instantiated.
+
+   b. Still warn, but return a ``SkyCoord``, not an instance of its class type (by 
    overriding ``__new__``)
-   3. Remove.
+   
+   c. Remove.
 
 The 3 steps (at stage 3a) are illustrated in the following pseudocode:
 

--- a/APE26.rst
+++ b/APE26.rst
@@ -15,7 +15,7 @@ Abstract
 Following the rationale presented in `APE 5 
 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_, 
 coordinate frames in astropy.coordinates currently store metadata 
-used to construct the frame (i.e. for transforming between frames) 
+used to construct the frame (i.e., for transforming between frames) 
 and may also store coordinate *data* itself. This duplicates 
 functionality with ``SkyCoord``, which acts as a container for both 
 coordinate data and reference frame information. We propose to 

--- a/APE26.rst
+++ b/APE26.rst
@@ -12,117 +12,153 @@ Authors (alphabetical): Jeff Jennings, Adrian Price-Whelan, Nathaniel Starkman, 
 
 Abstract
 --------
-Following the rationale presented in `APE 5 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_,
-coordinate frames in astropy.coordinates currently store metadata used to construct the
-frame (i.e. for transforming between frames) and may also store coordinate *data* itself.
-This duplicates functionality with ``SkyCoord``, which acts as a container for both
-coordinate data and reference frame information. We propose to change the frame classes
-such that they only store metadata and never coordinate data, superseding this aspect 
-of the implementation in `APE 5 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_. 
-This would make the implementation more modular and performant, remove ambiguity for users from having 
-nearly duplicate functionality with slightly different APIs, and better satisfy the 
-principle of Separation of Concerns.
+Following the rationale presented in `APE 5 
+<https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_, 
+coordinate frames in astropy.coordinates currently store metadata 
+used to construct the frame (i.e. for transforming between frames) 
+and may also store coordinate *data* itself. This duplicates 
+functionality with ``SkyCoord``, which acts as a container for both 
+coordinate data and reference frame information. We propose to 
+change the frame classes such that they only store metadata and 
+never coordinate data, superseding this aspect of the implementation 
+in `APE 5 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_. 
+This would make the implementation more modular and performant, 
+remove ambiguity for users from having nearly duplicate functionality 
+with slightly different APIs, and better satisfy the principle of 
+Separation of Concerns.
 
 Detailed description
 --------------------
-The coordinate frame classes (subclasses of ``BaseCoordinateFrame``, e.g., ``ICRS``,
-``Galactic``, ``FK4``, etc.) are used to represent astronomical reference frames. These
-may also contain position, velocity, time, or other information about the reference frame
-relative to another reference frame, which is used to transform coordinates between the
-reference frames that exist in the ``astropy.coordinates`` ecosystem. For example, the
-``AltAz`` frame class, which is used when referencing sky coordinates in altitude and
-azimuth, must contain a location on Earth and a time in order to transform to and from a
-fixed reference frame like the ICRS. In addition to reference frame information, these
-frame classes can **also** contain coordinate data (positions, velocities, or other
-differentials), which are stored internally using the ``Representation`` and
-``Differential`` classes.
+The coordinate frame classes (subclasses of ``BaseCoordinateFrame``, 
+e.g., ``ICRS``, ``Galactic``, ``FK4``, etc.) are used to represent 
+astronomical reference frames. These may also contain position, 
+velocity, time, or other information about the reference frame 
+relative to another reference frame, which is used to transform 
+coordinates between the reference frames that exist in the 
+``astropy.coordinates`` ecosystem. For example, the ``AltAz`` frame 
+class, which is used when referencing sky coordinates in altitude 
+and azimuth, must contain a location on Earth and a time in order 
+to transform to and from a fixed reference frame like the ICRS. In 
+addition to reference frame information, these frame classes can 
+**also** contain coordinate data (positions, velocities, or other 
+differentials), which are stored internally using the 
+``Representation`` and ``Differential`` classes.
 
-The above reflects a design choice in the coordinate frame implementation in 
-`APE 5 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_ that, following 
-several years of use, we have learned from and think best to revise. We now view it as an 
-insufficient `separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`_.
-The coordinate frame class deals with two separate issues: the definition of the frame
-and the storage of coordinate data within that frame. Ideally the code would be more
-modularly structured, where the coordinate frame class **only** defines the reference
-frame. It would then be the purview of another class – like ``SkyCoord`` or the newly-proposed ``Coordinate`` – to bring these
-concerns together and to represent data (using ``Representation`` and ``Differential``
-classes) in a given reference frame (using a ``CoordinateFrame`` class). As a demonstration
-of the current state of duplicated functionality, these two initializations effectively
-represent the same thing, but return different objects with similar but not identical
-APIs:
+The above reflects a design choice in the coordinate frame 
+implementation in `APE 5 
+<https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_ 
+that, following several years of use, we have learned from and 
+think best to revise. We now view it as an insufficient 
+`separation of concerns 
+<https://en.wikipedia.org/wiki/Separation_of_concerns>`_. The 
+coordinate frame class deals with two separate issues: the 
+definition of the frame and the storage of coordinate data within 
+that frame. Ideally the code would be more modularly structured, 
+where the coordinate frame class **only** defines the reference 
+frame. It would then be the purview of another class – like 
+``SkyCoord`` or the newly-proposed ``Coordinate`` – to bring these 
+concerns together and to represent data (using ``Representation`` 
+and ``Differential`` classes) in a given reference frame (using a 
+``CoordinateFrame`` class). As a demonstration of the current state 
+of duplicated functionality, these two initializations effectively 
+represent the same thing, but return different objects with similar 
+but not identical APIs:
 
 .. code-block:: python
 
     c1 = SkyCoord(1., 2., frame="icrs", units="deg")
     c2 = ICRS(1. * u.deg, 2. * u.deg)
 
-We suggest the situation should instead be analogous to what is the case for units,
-which know how to transform from one to another, but are not concerned with how the
-values are stored (that belongs to ``Quantity``). Translating to coordinates, units are
-like ``CoordinateFrame``, the values are the coordinate data (``Representations``), and
-``Quantity`` is like ``SkyCoord``.
+We suggest the situation should instead be analogous to what is the 
+case for units, which know how to transform from one to another, but 
+are not concerned with how the values are stored (that belongs to 
+``Quantity``). Translating to coordinates, units are like 
+``CoordinateFrame``, the values are the coordinate data 
+(``Representations``), and ``Quantity`` is like ``SkyCoord``.
 
-Having both the frame classes as well as ``SkyCoord`` be able to store and handle data
-has resulted in a large amount of code duplication (not just in the code proper, but
-also in the tests, leading to missed combinations). Restructuring the ``Frame`` classes
-to remove data storage will allow for much more maintainable, de-duplicated code. It
-will also make it easier to contribute: if there is a problem one would like to solve
-in a given method, if one looks in ``SkyCoord``, one will likely find that it does not
-exist, but instead is defined on ``BaseCoordinateFrame`` and gets dynamically called via
-``SkyCoord.__getattr__``. Indeed, the construction of ``BaseCoordinateFrame`` ends up
-complicating ``SkyCoord``, which has to manage the coordinate data **through** the stored
+Having both the frame classes as well as ``SkyCoord`` be able to
+store and handle data has resulted in a large amount of code
+duplication (not just in the code proper, but also in the tests,
+leading to missed combinations). Restructuring the ``Frame``
+classes to remove data storage will allow for much more
+maintainable, de-duplicated code. It will also make it easier to
+contribute: if there is a problem one would like to solve in a
+given method, if one looks in ``SkyCoord``, one will likely find
+that it does not exist, but instead is defined on
+``BaseCoordinateFrame`` and gets dynamically called via
+``SkyCoord.__getattr__``. Indeed, the construction of
+``BaseCoordinateFrame`` ends up complicating ``SkyCoord``, which
+has to manage the coordinate data **through** the stored
 ``BaseCoordinateFrame``.
 
-Another issue with the current implementation of coordinate frames is that the optional
-inclusion of coordinate data makes the reference frames “multi-modal”. This creates
-different usage modes (with and without data), each exhibiting different behavior. For
-instance, some methods such as ``separation`` work fine with frames with data, while
-doing this on coordinate frames without data results in an error. While this multi-modal 
-structure as motivated in `APE 5 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_ 
-can be seen as a benefit for interpretability of the logic, we also now see it from the
-perspective of an anti-pattern. It forces any code interacting with the frame classes 
-to handle both cases (checking ``frame.has_data``), complicating the codebase. 
-Moreover static analyzers cannot determine which case is being used; with separated frames and data static analyzers will be able to prevent this entire class of errors.
-We thus 
-find it worthwhile to separate coordinate data from reference frames at the possible 
-expense of developers having to learn this new framework.
+Another issue with the current implementation of coordinate
+frames is that the optional inclusion of coordinate data makes
+the reference frames “multi-modal”. This creates different usage
+modes (with and without data), each exhibiting different
+behavior. For instance, some methods such as ``separation`` work
+fine with frames with data, while doing this on coordinate frames
+without data results in an error. While this multi-modal
+structure as motivated in `APE 5
+<https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_
+can be seen as a benefit for interpretability of the logic, we
+also now see it from the perspective of an anti-pattern. It
+forces any code interacting with the frame classes to handle both
+cases (checking ``frame.has_data``), complicating the codebase.
+Moreover static analyzers cannot determine which case is being
+used; with separated frames and data static analyzers will be
+able to prevent this entire class of errors. We thus find it
+worthwhile to separate coordinate data from reference frames at
+the possible expense of developers having to learn this new
+framework.
 
-All the points discussed thus far – separation of concerns and code duplication –
-concern maintainers. However user experience is the more important consideration. In
-this arena too, separating frames from data storage has its advantages. Perhaps most
-importantly, documentation will be more obvious: the methods and attributes are defined
-on ``SkyCoord`` (and ``Coordinate``) proper, so sphinx will know how to typeset those, while type checkers
-can help users in finding and using them properly. It will also be easier:
-following the Zen of Python, there should be one clear way to do something. The present
-overlap leads to confusion wherein beginner users end up creating ``BaseCoordinateFrame``
-objects such as ``ICRS``, when the docs are clear that these are for more advanced users
-and that ``SkyCoord`` is to be preferred.
-The system will also be less fragile. For example, if users manipulate the 
-internal workings of ``SkyCoord`` (which is discouraged but possible), the coordinate 
-data can become decoupled from the caching that ``SkyCoord`` performs for speed. With these proposed changes users will have a more clear, introspectable, and robust system.
+All the points discussed thus far – separation of concerns and
+code duplication – concern maintainers. However user experience
+is the more important consideration. In this arena too,
+separating frames from data storage has its advantages. Perhaps
+most importantly, documentation will be more obvious: the methods
+and attributes are defined on ``SkyCoord`` (and ``Coordinate``)
+proper, so sphinx will know how to typeset those, while type
+checkers can help users in finding and using them properly. It
+will also be easier: following the Zen of Python, there should be
+one clear way to do something. The present overlap leads to
+confusion wherein beginner users end up creating
+``BaseCoordinateFrame`` objects such as ``ICRS``, when the docs
+are clear that these are for more advanced users and that
+``SkyCoord`` is to be preferred. The system will also be less
+fragile. For example, if users manipulate the internal workings
+of ``SkyCoord`` (which is discouraged but possible), the
+coordinate data can become decoupled from the caching that
+``SkyCoord`` performs for speed. With these proposed changes
+users will have a more clear, introspectable, and robust system.
 
 Finished Product
 ----------------
-The end result of the implementation of this APE are be two separate hierarchies
-of classes: reference frame classes and coordinate classes which bring together
-a reference frame and coordinate data. We discuss each class type in turn.
+The end result of the implementation of this APE are be two separate
+hierarchies of classes: reference frame classes and coordinate
+classes which bring together a reference frame and coordinate
+data. We discuss each class type in turn.
 
-Coordinate frame classes only hold information pertaining to the reference frame
-they represent and never actual coordinate data in that reference frame. This is
-consistent with our mathematical framework, the reference frame mediates how
-coordinate data is understood (e.g. distance measures) or interacts (e.g.
-separation from other coordinates), but the coordinate data itself is actually
-independent of that information.
+Coordinate frame classes only hold information pertaining to
+the reference frame they represent and never actual coordinate
+data in that reference frame. This is consistent with our
+mathematical framework, the reference frame mediates how
+coordinate data is understood (e.g. distance measures) or
+interacts (e.g. separation from other coordinates), but the
+coordinate data itself is actually independent of that
+information.
 
-Classes like ``SkyCoord`` will be composed structures bringing together the
-reference frame (an instance of a ``BaseFrame`` subclass) and the coordinate
-data (``BaseRepresentation`` objects). We also introduce a new class,
-``Coordinate``, which is akin to ``SkyCoord`` (containing both frame and data),
-but without extra features like keeping frame attributes not associated with the current frame, caching and flexible input parsing. In this way
-``Coordinate`` operates very similarly to the current ``BaseCoordinateFrame``
-objects when they have data, and is meant to be their direct replacement in the
-new framework as well as a more lightweight and performant alternative to
-``SkyCoord``. 
+Classes like ``SkyCoord`` will be composed structures bringing
+together the reference frame (an instance of a ``BaseFrame``
+subclass) and the coordinate data (``BaseRepresentation``
+objects). We also introduce a new class, ``Coordinate``, which
+is akin to ``SkyCoord`` (containing both frame and data), but
+without extra features like keeping frame attributes not
+associated with the current frame, caching and flexible input
+parsing. In this way ``Coordinate`` operates very similarly to
+the current ``BaseCoordinateFrame`` objects when they have
+data, and is meant to be their direct replacement in the new
+framework as well as a more lightweight and performant
+alternative to ``SkyCoord``.
 
 We illustrate the new framework with the following pseudocode.
 
@@ -153,65 +189,82 @@ We illustrate the new framework with the following pseudocode.
 
 Branches and pull requests
 --------------------------
-No direct progress on these changes has yet occurred. Discussion of these ideas has
-however arisen in multiple issues and pull requests, demonstrating the need for and
-utility of the proposed changes.
+No direct progress on these changes has yet occurred. Discussion
+of these ideas has however arisen in multiple issues and pull
+requests, demonstrating the need for and utility of the proposed
+changes.
 
-Several issues have been raised regarding topics such as confusion differentiating the
-use of ``frame`` and ``SkyCoord`` for data storage, and problems arising in other astropy
+Several issues have been raised regarding topics such as
+confusion differentiating the use of ``frame`` and ``SkyCoord``
+for data storage, and problems arising in other astropy
 subpackages when using frames that store data. For example:
 
-- `Comparing Frame with data and SkyCoord with same data raises exception #13476 <https://github.com/astropy/astropy/issues/13476>`_
-- `Add Frame objects without data to a Table #16823 <https://github.com/astropy/astropy/issues/16823>`_
+- `Comparing Frame with data and SkyCoord with same data raises 
+  exception #13476 
+  <https://github.com/astropy/astropy/issues/13476>`_
+- `Add Frame objects without data to a Table #16823 
+  <https://github.com/astropy/astropy/issues/16823>`_
 
-Additionally, multiple pull requests have factored out common code between frames and
-``SkyCoord``, showing that there is no proper separation of concern:
+Additionally, multiple pull requests have factored out common 
+code between frames and ``SkyCoord``, showing that there is no 
+proper separation of concern:
 
-- `Allow BaseCoordinateFrames to be stored in tables (by giving them .info) #16831 <https://github.com/astropy/astropy/pull/16831>`_
-- `Masked frames and SkyCoord #17106 <https://github.com/astropy/astropy/pull/17016>`_ (this was later removed and instead methods were duplicated)
+- `Allow BaseCoordinateFrames to be stored in tables (by giving 
+  them .info) #16831 <https://github.com/astropy/astropy/pull/16831>`_
+- `Masked frames and SkyCoord #17106 
+  <https://github.com/astropy/astropy/pull/17016>`_ (this was later 
+  removed and instead methods were duplicated)
 
-Further, pull requests have added methods to make frames and ``SkyCoord`` even more
-similar, underscoring that frames *with* data should not be separate entities from
-``SkyCoord``:
+Further, pull requests have added methods to make frames and 
+``SkyCoord`` even more similar, underscoring that frames *with* 
+data should not be separate entities from ``SkyCoord``:
 
-- `Implement BaseCoordinateFrame.to_table() #17009 <https://github.com/astropy/astropy/pull/17009>`_
-- `Implement BaseCoordinateFrame.frame property #16356 <https://github.com/astropy/astropy/pull/16356>`_
+- `Implement BaseCoordinateFrame.to_table() #17009 
+  <https://github.com/astropy/astropy/pull/17009>`_
+- `Implement BaseCoordinateFrame.frame property #16356 
+  <https://github.com/astropy/astropy/pull/16356>`_
 
-In addition, many of these ideas have been developed and tested in parallal in
-the JAX-oriented library `coordinax
-<https://github.com/GalacticDynamics/coordinax>`_. Many of the developers of
-that library are also active Astropy developers and the development effort
-towards ``coordinax`` informs, tests, and validates the ideas presented in this
-APE. In short, it works.
+In addition, many of these ideas have been developed and tested in
+parallal in the JAX-oriented library `coordinax
+<https://github.com/GalacticDynamics/coordinax>`_. Many of the
+developers of that library are also active Astropy developers and
+the development effort towards ``coordinax`` informs, tests, and
+validates the ideas presented in this APE. In short, it works.
 
 
 Implementation
 --------------
-The direct use of coordinate frames instead of ``SkyCoord`` is common. In particular
-``ICRS`` objects are frequently created with data. Given the prevalent use, it is imperative
-to maintain backward compatibility and not break the API too quickly. Therefore, we
-propose implementing this APE through 4 steps (and substeps).
+The direct use of coordinate frames instead of ``SkyCoord`` is 
+common. In particular ``ICRS`` objects are frequently created 
+with data. Given the prevalent use, it is imperative to maintain 
+backward compatibility and not break the API too quickly. 
+Therefore, we propose implementing this APE through 4 steps (and 
+substeps).
 
-1. Splitting the frame classes into two hierarchies: ones with and without data, with
-the data-less ones getting new names.
+1. Splitting the frame classes into two hierarchies: ones with 
+   and without data, with the data-less ones getting new names.
 
-2. Adding a new ``Coordinate`` class that is similar to ``SkyCoord``, but which
-   does not keep any frame attributes not in the current frame, and does not
-   have extra features like caching and flexible input parsing. It will only
-   accept data-less frame classes.
+2. Adding a new ``Coordinate`` class that is similar to 
+   ``SkyCoord``, but which does not keep any frame attributes not 
+   in the current frame, and does not have extra features like 
+   caching and flexible input parsing. It will only accept 
+   data-less frame classes.
 
-3. Switching ``SkyCoord`` to use the data-less frame classes, and enabling automatic
-conversion of the with-data frames into ``SkyCoord`` objects.
+3. Switching ``SkyCoord`` to use the data-less frame classes, and 
+   enabling automatic conversion of the with-data frames into 
+   ``SkyCoord`` objects.
 
 4. Deprecating the legacy with-data frame classes.
 
    - Emitting warnings when instantiated.
 
-   - Still warn, but return a ``Coordinate``, not an instance of its class type (by overriding ``__new__``)
+   - Still warn, but return a ``Coordinate``, not an instance of 
+     its class type (by overriding ``__new__``)
 
    - Remove.
 
-The third step (at stage 3a) is illustrated in the following pseudocode:
+The third step (at stage 3a) is illustrated in the following 
+pseudocode:
 
 .. code-block:: python
 

--- a/APE26.rst
+++ b/APE26.rst
@@ -117,7 +117,7 @@ is the more important consideration. In this arena too,
 separating frames from data storage has its advantages. Perhaps
 most importantly, documentation will be more obvious: the methods
 and attributes are defined on ``SkyCoord`` (and ``Coordinate``)
-proper, so sphinx will know how to typeset those, while type
+proper, so `Sphinx <https://www.sphinx-doc.org/>`_ will know how to typeset those, while type
 checkers can help users in finding and using them properly. It
 will also be easier: following the Zen of Python, there should be
 one clear way to do something. The present overlap leads to

--- a/APE26.rst
+++ b/APE26.rst
@@ -81,7 +81,7 @@ store and handle data has resulted in a large amount of code
 duplication. It has also required duplicated or even quadrupled 
 tests, in order to test both ``BaseCoordinateFrame`` and 
 ``SkyCoord`` methods with both ``BaseCoordinateFrame`` and 
-``SkyCoord`` arguments - where the tests have not caught every 
+``SkyCoord`` arguments - where the tests have not covered every 
 combination, problems have gone unnoticed. Restructuring the 
 ``frame`` classes to remove data storage will allow for much more
 maintainable, de-duplicated code. It will also make it easier to

--- a/APE26.rst
+++ b/APE26.rst
@@ -271,7 +271,9 @@ substeps).
    - Emitting warnings when instantiated.
 
    - Still warn, but return a ``Coordinate``, not an instance of 
-     its class type (by overriding ``__new__``)
+     its class type (by overriding ``__new__``). If there are 
+     justified objections to overriding ``__new__``, an 
+     alternative would be to prolong the deprecation period.
 
    - Remove.
 

--- a/APE26.rst
+++ b/APE26.rst
@@ -55,12 +55,19 @@ coordinate frame class deals with two separate issues: the
 definition of the frame and the storage of coordinate data within 
 that frame. Ideally the code would be more modularly structured, 
 where the coordinate frame class **only** defines the reference 
-frame. It would then be the purview of another class – like 
+frame. This was considered in APE 5 (discussed as one
+`alternative <https://github.com/jeffjennings/ape26_scratch/blob/main/demo.ipynb>`_ 
+to the implementation pursued there), but it was deemed too difficult 
+to implement the 'high-level' classes as 
+`generics <https://typing.python.org/en/latest/reference/generics.html>`_.
+With the proposed framework in this APE, we no longer find such a 
+difficulty; the coordinate frame class only defines the 
+reference frame, and it becomes the purview of another class – like 
 ``SkyCoord`` or the newly-proposed ``Coordinate`` – to bring these 
 concerns together and to represent data (using ``BaseRepresentation`` 
 and ``BaseDifferential`` subclasses) in a given reference frame (using a 
-``CoordinateFrame`` class). As a demonstration of the current state 
-of duplicated functionality, these two initializations effectively 
+``CoordinateFrame`` class). As a demonstration of the current state of 
+duplicated functionality, these two initializations effectively 
 represent the same thing, but return different objects with similar 
 but not identical APIs:
 
@@ -69,8 +76,8 @@ but not identical APIs:
     c1 = SkyCoord(1., 2., frame="icrs", units="deg")
     c2 = ICRS(1. * u.deg, 2. * u.deg)
 
-Consequently user confusion can arise from an operation as common as
-transforming reference frames:
+Consequently, as one simple example, user confusion can arise from an 
+operation as common as transforming reference frames:
 
 .. code-block:: python     
 
@@ -349,9 +356,9 @@ pseudocode:
         ...
 
 We also provide a fuller `prototype 
-<https://github.com/user-attachments/files/24824365/ape26_prototype.py>` 
+<https://github.com/jeffjennings/ape26_scratch/blob/main/ape26_prototype.py>` 
 and a
-`demo notebook <https://github.com/user-attachments/files/24824366/demo.ipynb>`
+`demo notebook <https://github.com/jeffjennings/ape26_scratch/blob/main/demo.ipynb>`
 implementing these changes.
 
 Usage patterns

--- a/APE26.rst
+++ b/APE26.rst
@@ -354,3 +354,91 @@ and a
 `demo notebook <https://github.com/user-attachments/files/24824366/demo.ipynb>`
 implementing these changes.
 
+Usage patterns
+--------------
+The following pseudocode presents typical use cases of the 
+new framework at each of the four steps outlined in the 
+previous section.
+
+.. code-block:: python
+
+    # === Step 1 ===
+
+    # Unchanging API
+    # Normal type hierarchy
+    ra, dec = ..., ...
+    rep = SphericalRepresentation(ra, dec)
+    c = ICRS(rep)  # the same. not yet deprecated.
+    sc = SkyCoord(c)
+    # Flexible inputs
+    c = ICRS(ra_arr, dec_arr)  # the same. not yet deprecated.
+    c = ICRS(rep)  # the same. not yet deprecated.
+    sc = SkyCoord(ra_arr, dec_arr, frame=ICRS())  # the same. not yet deprecated.
+    sc = SkyCoord(rep, frame=ICRS())  # the same. not yet deprecated.
+
+    # New API
+    frame = ICRSFrame()
+    sc = SkyCoord(rep, frame=frame)
+    sc = SkyCoord(ra_arr, dec_arr, frame=frame)
+
+    # === Step 2 ===
+
+    # Unchanging API
+    # Normal type hierarchy
+    ra, dec = ..., ...
+    rep = SphericalRepresentation(ra, dec)
+    c = ICRS(rep)  # the same. not yet deprecated.
+    sc = SkyCoord(c)
+    # Flexible inputs
+    c = ICRS(ra_arr, dec_arr)  # the same. not yet deprecated.
+    c = ICRS(rep)  # the same. not yet deprecated.
+    sc = SkyCoord(ra_arr, dec_arr, frame=ICRS())  # the same. not yet deprecated.
+    sc = SkyCoord(rep, frame=ICRS())  # the same. not yet deprecated.
+
+    # New API
+    frame = ICRSFrame()
+    c = Coordinate(rep, frame)
+    sc = SkyCoord(rep, frame=frame)
+    sc = SkyCoord(c.data, c.frame)  # (just showing the strict constructor)
+    sc = SkyCoord(c)  # flexible
+    sc = SkyCoord(ra_arr, dec_arr, frame=frame)  # flexible
+
+    # === Step 3 ===
+    # Unchanging API
+    # Normal type hierarchy
+    ra, dec = ..., ...
+    rep = SphericalRepresentation(ra, dec)
+    c = ICRS(rep)  # the same. not yet deprecated.
+    sc = SkyCoord(c)
+    # Flexible inputs
+    c = ICRS(ra_arr, dec_arr)  # the same. not yet deprecated.
+    c = ICRS(rep)  # the same. not yet deprecated.
+    sc = SkyCoord(ra_arr, dec_arr, frame=ICRS())  # redirects to SkyCoord(ra_arr, dec_arr, frame=ICRSFrame()) 
+    sc = SkyCoord(rep, frame=ICRS())  # redirects to SkyCoord(ra_arr, dec_arr, frame=ICRSFrame()) 
+
+    # New API
+    frame = ICRSFrame()
+    c = Coordinate(rep, frame)
+    sc = SkyCoord(rep, frame=frame)
+    sc = SkyCoord(c)  # flexible
+    sc = SkyCoord(ra_arr, dec_arr, frame=frame)  # flexible
+
+    # === Step 4 ===
+    # Unchanging API
+    # Normal type hierarchy
+    ra, dec = ..., ...
+    rep = SphericalRepresentation(ra, dec)
+
+    # Deprecated API
+    c = ICRS(rep)
+    c = ICRS(ra_arr, dec_arr)
+    sc = SkyCoord(c)
+    sc = SkyCoord(ra_arr, dec_arr, frame=ICRS())  # ICRS -> ICRSFrame 
+    sc = SkyCoord(rep, frame=ICRS())  # ICRS -> ICRSFrame
+
+    # New API
+    frame = ICRSFrame()
+    c = Coordinate(rep, frame)
+    sc = SkyCoord(rep, frame=frame)
+    sc = SkyCoord(c)  # flexible
+    sc = SkyCoord(ra_arr, dec_arr, frame=frame)  # flexible

--- a/APE26.rst
+++ b/APE26.rst
@@ -69,6 +69,16 @@ but not identical APIs:
     c1 = SkyCoord(1., 2., frame="icrs", units="deg")
     c2 = ICRS(1. * u.deg, 2. * u.deg)
 
+Consequently user confusion can arise from an operation as common as
+transforming reference frames:
+
+.. code-block:: python     
+
+    c1g = c1.transform_to(Galactic())  # Works
+    c2g = c2.transform_to(Galactic())  # Works
+    c1g = c1.transform_to("galactic")  # Works
+    c2g = c2.transform_to("galactic")  # Raises ConvertError
+
 We suggest the situation should instead be analogous to what is the 
 case for units, which know how to transform from one to another, but 
 are not concerned with how the values are stored (that belongs to 
@@ -120,7 +130,7 @@ worthwhile to separate coordinate data from reference frames at
 the possible expense of developers having to learn this new
 framework.
 
-All the points discussed thus far – separation of concerns and
+The major points discussed thus far – separation of concerns and
 code duplication – concern maintainers. However user experience
 is the more important consideration. In this arena too,
 separating frames from data storage has its advantages. Perhaps

--- a/APE26.rst
+++ b/APE26.rst
@@ -86,12 +86,13 @@ operation as common as transforming reference frames:
     c1g = c1.transform_to("galactic")  # Works
     c2g = c2.transform_to("galactic")  # Raises ConvertError
 
-We suggest the situation should instead be analogous to what is the 
-case for units, which know how to transform from one to another, but 
-are not concerned with how the values are stored (that belongs to 
-``Quantity``). Translating to coordinates, units are like 
-``CoordinateFrame``, the values are the coordinate data 
-(``BaseRepresentation``), and ``Quantity`` is like ``SkyCoord``.
+We suggest the situation should instead be analogous to the structure 
+implemented for ``astropy.units``: the ``Unit`` class is able to 
+transform between units, but it is not concerned with how the 
+associated values are stored (which is instead handled by ``Quantity``).
+Translating to coordinates, units are like ``CoordinateFrame``, the 
+values are the coordinate data (``BaseRepresentation``), and ``Quantity`` 
+is like ``SkyCoord``.
 
 Having both the frame classes as well as ``SkyCoord`` be able to
 store and handle data has resulted in a few notable types of
@@ -122,8 +123,8 @@ frames is that the optional inclusion of coordinate data makes
 the reference frames “multi-modal”. This creates different usage
 modes (with and without data), each exhibiting different
 behavior. For instance, some methods such as ``separation`` work
-fine with frames with data, while doing this on coordinate frames
-without data results in an error. While this multi-modal
+for coordinate-frame instances that contain data, but they lead to 
+faults for instances without data. While this multi-modal
 structure as motivated in `APE 5
 <https://github.com/astropy/astropy-APEs/blob/main/APE5.rst>`_
 can be seen as a benefit for interpretability of the logic, we
@@ -165,7 +166,7 @@ hierarchies of classes: reference frame classes and coordinate
 classes which bring together a reference frame and coordinate
 data. We discuss each class type in turn.
 
-Coordinate frame classes only hold information pertaining to
+Reference frame classes only hold information pertaining to
 the reference frame they represent and never actual coordinate
 data in that reference frame. This is consistent with our
 mathematical framework, as the reference frame mediates how
@@ -265,8 +266,9 @@ The direct use of coordinate frames instead of ``SkyCoord`` is
 common. In particular ``ICRS`` objects are frequently created 
 with data. Given the prevalent use, it is imperative to maintain 
 backward compatibility and not break the API too quickly. 
-Therefore, we propose implementing this APE through 4 steps (and 
-substeps).
+Therefore, we propose implementing this APE through the 4 steps 
+(and substeps) below. See the *Usage patterns* section for 
+practical examples of how to use the new framework.
 
 1. Splitting the frame classes into two hierarchies: ones with 
    and without data, with the data-less ones getting new names.

--- a/APE26.rst
+++ b/APE26.rst
@@ -347,3 +347,10 @@ pseudocode:
 
     class FK5(BaseCoordinateFrame, FK5Frame):
         ...
+
+We also provide a fuller `prototype 
+<https://github.com/user-attachments/files/24824365/ape26_prototype.py>` 
+and a
+`demo notebook <https://github.com/user-attachments/files/24824366/demo.ipynb>`
+implementing these changes.
+

--- a/APE26.rst
+++ b/APE26.rst
@@ -43,7 +43,7 @@ to transform to and from an inertial reference frame like the ICRS. In
 addition to reference frame information, these frame classes can 
 **also** contain coordinate data (positions, velocities, or other 
 differentials), which are stored internally using the 
-``Representation`` and ``Differential`` classes.
+``BaseRepresentation`` and ``BaseDifferential`` subclasses.
 
 The above reflects a design choice in the coordinate frame 
 implementation in `APE 5 

--- a/APE26.rst
+++ b/APE26.rst
@@ -5,7 +5,7 @@ Authors (alphabetical): Jeff Jennings, Adrian Price-Whelan, Nathaniel Starkman, 
 ---------------------------------------------------------------------------------------------------
 
 :date-created: 2024 11 04
-:date-last-revised: 2025 04 28
+:date-last-revised: 2026 01 23
 :date-accepted: 202x xx xx
 :type: Standard Track
 :status: Discussion
@@ -77,8 +77,14 @@ are not concerned with how the values are stored (that belongs to
 (``BaseRepresentation``), and ``Quantity`` is like ``SkyCoord``.
 
 Having both the frame classes as well as ``SkyCoord`` be able to
-store and handle data has resulted in a large amount of code
-duplication. It has also required duplicated or even quadrupled 
+store and handle data has resulted in a few notable types of
+issues. First, it has results in a large amount of code
+duplication. Second, the reliance on `SkyCoord.__getattr__()` 
+has led to at least one method that `SkyCoord` implements 
+accidentally (`astropy/astropy#15643
+<https://github.com/astropy/astropy/issues/15643>`_), and there 
+may be more. Third, having both the frame classes and 
+`SkyCoord` has also required duplicated or even quadrupled 
 tests, in order to test both ``BaseCoordinateFrame`` and 
 ``SkyCoord`` methods with both ``BaseCoordinateFrame`` and 
 ``SkyCoord`` arguments - where the tests have not covered every 
@@ -108,7 +114,7 @@ also now see it from the perspective of an anti-pattern. It
 forces any code interacting with the frame classes to handle both
 cases (checking ``frame.has_data``), complicating the codebase.
 Moreover static analyzers cannot determine which case is being
-used; with separated frames and data static analyzers will be
+used; with separated frames and data, static analyzers will be
 able to prevent this entire class of errors. We thus find it
 worthwhile to separate coordinate data from reference frames at
 the possible expense of developers having to learn this new
@@ -137,7 +143,7 @@ more clear, introspectable, and robust system.
 
 Finished Product
 ----------------
-The end result of the implementation of this APE are be two separate
+The end result of the implementation of this APE will be two separate
 hierarchies of classes: reference frame classes and coordinate
 classes which bring together a reference frame and coordinate
 data. We discuss each class type in turn.
@@ -145,7 +151,7 @@ data. We discuss each class type in turn.
 Coordinate frame classes only hold information pertaining to
 the reference frame they represent and never actual coordinate
 data in that reference frame. This is consistent with our
-mathematical framework, the reference frame mediates how
+mathematical framework, as the reference frame mediates how
 coordinate data is understood (e.g., distance measures) or
 interacts (e.g., separation from other coordinates), but the
 coordinate data itself is actually independent of that

--- a/APE26.rst
+++ b/APE26.rst
@@ -74,7 +74,7 @@ case for units, which know how to transform from one to another, but
 are not concerned with how the values are stored (that belongs to 
 ``Quantity``). Translating to coordinates, units are like 
 ``CoordinateFrame``, the values are the coordinate data 
-(``Representations``), and ``Quantity`` is like ``SkyCoord``.
+(``BaseRepresentation``), and ``Quantity`` is like ``SkyCoord``.
 
 Having both the frame classes as well as ``SkyCoord`` be able to
 store and handle data has resulted in a large amount of code

--- a/APE26.rst
+++ b/APE26.rst
@@ -57,8 +57,8 @@ that frame. Ideally the code would be more modularly structured,
 where the coordinate frame class **only** defines the reference 
 frame. It would then be the purview of another class – like 
 ``SkyCoord`` or the newly-proposed ``Coordinate`` – to bring these 
-concerns together and to represent data (using ``Representation`` 
-and ``Differential`` classes) in a given reference frame (using a 
+concerns together and to represent data (using ``BaseRepresentation`` 
+and ``BaseDifferential`` subclasses) in a given reference frame (using a 
 ``CoordinateFrame`` class). As a demonstration of the current state 
 of duplicated functionality, these two initializations effectively 
 represent the same thing, but return different objects with similar 

--- a/APE5.rst
+++ b/APE5.rst
@@ -28,6 +28,10 @@ provides a more user-friendly interface.  The transformation  framework will
 remain essentially unchanged, except that it will operate specifically on the
 low-level classes.
 
+UPDATE: Portions of the implementation presented here are amended in `APE 26 
+<https://github.com/astropy/astropy-APEs/blob/main/APE26.rst>`_. See that APE for 
+further discussion.
+
 
 Detailed description
 --------------------

--- a/APE5.rst
+++ b/APE5.rst
@@ -5,13 +5,15 @@ authors: Erik Tollerud, Adrian Price-Whelan, Thomas Aldcroft, Thomas Robitalle
 
 date-created: 2014 January 22
 
-date-last-revised: 2014 March 9
+date-last-revised: 2026 January 23
 
 date-accepted: 2014 March 9
 
 type: Standard Track
 
 status: Accepted
+
+revised-by: Jeff Jennings - 2026 January 23 - Added note on APE 26 alterations to APE 5.
 
 Abstract
 --------
@@ -28,10 +30,9 @@ provides a more user-friendly interface.  The transformation  framework will
 remain essentially unchanged, except that it will operate specifically on the
 low-level classes.
 
-UPDATE: Portions of the implementation presented here are amended in `APE 26 
-<https://github.com/astropy/astropy-APEs/blob/main/APE26.rst>`_. See that APE for 
-further discussion.
-
+.. note:: January 23, 2026: Portions of the implementation presented here are amended in `APE 26 
+  <https://github.com/astropy/astropy-APEs/blob/main/APE26.rst>`_. See that APE for 
+  further discussion.
 
 Detailed description
 --------------------


### PR DESCRIPTION
Coordinate frames in `astropy.coordinates` currently store metadata used to construct the frame (i.e. for transforming between frames) and may also store coordinate data itself. This duplicates functionality with `SkyCoord`, which acts as a container for both coordinate data and reference frame information. We propose to change the frame classes such that they only store metadata and never coordinate data. This would make the implementation more modular, remove ambiguity for users from having nearly duplicate functionality with slightly different APIs, and better satisfy the principle of Separation of Concerns.

Authors of this APE (alphabetical): Jeff Jennings @jeffjennings, Adrian Price-Whelan @adrn, Nathaniel Starkman @nstarman, Marten van Kerkwijk @mhvk 