### PR TITLE
Removing CoCo Term Limit Language from APE 0

### DIFF
--- a/APE0.rst
+++ b/APE0.rst
@@ -152,9 +152,8 @@ term or decided to step down.
 Term
 ^^^^
 Each Coordination Committee member's term runs for three years from when
-the election results are finalized. After serving two full terms, a Coordination
-Committee member must step down for at least one year before being eligible to
-run again.
+the election results are finalized. here is no limit to the number of terms
+that a single individual can be elected for.
 
 In the case of a vacancy partway through a term, a by-election will be held.
 The term of the newly-elected member runs for the remainder of the term of


### PR DESCRIPTION
This PR is to remove CoCo term limits from APE 0.

**Context:** In the last vote to change APE 0 the presence of non-active voting members on our active voting member role, combined with incorrect/confusing voting options being offered to voters (inclusion of an abstain option which should not have been present, and multiple choice answers when all APE 0 changes should be in a Yes/No format) led to uncertain outcomes to for some of the changes being voted on. At the time we provisionally included several of the changes that seemed likely to pass, but were not  certain due to the election irregularities. Of those provisional inclusions, all were subsequently ratified except for the term limits for CoCo members. Thus, this PR removes those changes.

**Effects:** There has been one CoCo election since this language was provisionally added to APE0, however the limits spelled out did not prevent anyone from running (the CoCo member whose seat was up did not want to stand again regardless of their eligability), so this rule has not yet been used. Thus reverting this language simply continues the existing policy of having no term limits for the CoCo.