### PR TITLE
APE0: Amendment to APE0 voting requirements

### DIFF
--- a/APE0.rst
+++ b/APE0.rst
@@ -365,9 +365,11 @@ consensus of the community on accepting the final version.
 
 Changes to this Charter after it has been accepted should follow the
 modification process in `APE 1`_, with the exception that the final approval of
-the modification requires approval by a two-thirds vote of the
+the modification requires approval by a vote of the
 `Voting Members`_ rather than approval by the Coordination
-Committee.
+Committee. For a proposed change to this charter to be adopted it must secure a
+2/3 majority of vote participants, where the number of participants is at least 2/3
+of the total voting members.
 
 Attribution and Acknowledgments
 -------------------------------

--- a/APE0.rst
+++ b/APE0.rst
@@ -370,7 +370,7 @@ the modification requires approval by a vote of the
 Committee. For a proposed change to this charter to be adopted it must secure a
 2/3 majority of votes cast, where the number of participants is at least 2/3
 of the total electorate. Vote options shall be "yes," "no," and "abstain," where
-and abstain vote counts towards the participation count, but does not affect the
+an abstain vote counts towards the participation count, but does not affect the
 2/3 majority calculation.
 
 Attribution and Acknowledgments

--- a/APE0.rst
+++ b/APE0.rst
@@ -368,8 +368,8 @@ modification process in `APE 1`_, with the exception that the final approval of
 the modification requires approval by a vote of the
 `Voting Members`_ rather than approval by the Coordination
 Committee. For a proposed change to this charter to be adopted it must secure a
-2/3 majority of vote participants, where the number of participants is at least 2/3
-of the total voting members.
+2/3 majority of votes cast, where the number of participants is at least 2/3
+of the total electorate.
 
 Attribution and Acknowledgments
 -------------------------------

--- a/APE0.rst
+++ b/APE0.rst
@@ -369,7 +369,9 @@ the modification requires approval by a vote of the
 `Voting Members`_ rather than approval by the Coordination
 Committee. For a proposed change to this charter to be adopted it must secure a
 2/3 majority of votes cast, where the number of participants is at least 2/3
-of the total electorate.
+of the total electorate. Vote options shall be "yes," "no," and "abstain," where
+and abstain vote counts towards the participation count, but does not affect the
+2/3 majority calculation.
 
 Attribution and Acknowledgments
 -------------------------------


### PR DESCRIPTION
Per discussion at the Coordination Meeting this PR changes the requirements for adopting changes to APE0 (The Astropy Governance Charter) from a simple 2/3 majority of the electorate (voting members), to a 2/3 majority of votes cast, with a minimum electorial participation of 2/3.

Notes from the coordination meeting: https://docs.google.com/document/d/17zwz_7g4XdUOGR3oEtUQAqNbdYTDnxEhrxfDKM0mt7Q/edit?tab=t.0#heading=h.w0w9mixvcd44