### PR TITLE
APE0: Adding language about emeritizing voting members for non-voting

### DIFF
--- a/APE0.rst
+++ b/APE0.rst
@@ -331,8 +331,11 @@ Term and Active/Emeritus Status
 Voting Members have no term limits. Voting Members who have stopped
 contributing are encouraged to declare themselves as *emeritus*. Those who have
 not made any significant contribution for two years may be asked to move
-themselves to the *emeritus* category by the Coordination Committee. If no
-response is received, the Coordination Committee may automatically change a
+themselves to the *emeritus* category by the Coordination Committee.
+Additionally, otherwise active voting members who have not voted in the last
+4 elections may also be asked to move themselves to the *emeritus* category by
+the Coordination Committee.
+If no response is received, the Coordination Committee may automatically change a
 Voting Member’s status to *emeritus*. To record and honor their contributions,
 *emeritus* Voting Members will continue to be listed. *Emeritus* Voting Members
 are not able to participate in votes.


### PR DESCRIPTION
Per discussion at the Coordination Meeting, this PR adds language stating that the Coordination Committee can ask a voting member to move themself to emeritus status if they have not voted in the past 4 elections, even if they are otherwise active in the project.

Notes from the coordination meeting: https://docs.google.com/document/d/17zwz_7g4XdUOGR3oEtUQAqNbdYTDnxEhrxfDKM0mt7Q/edit?tab=t.0#heading=h.w0w9mixvcd44