### PR TITLE
updated APE8 to reflect the use of NF CoC

### DIFF
--- a/APE8.rst
+++ b/APE8.rst
@@ -11,7 +11,7 @@ date-accepted: 2015 May 17
 
 type: Informational
 
-status: Superceded
+status: Superseded
 
 Abstract
 --------
@@ -30,7 +30,16 @@ code or adapt it to their needs.
 Notice of Replacement
 ---------------------
 
-As of 2026, the Astropy Community Code of Conduct is superceded by the NumFOCUS Code of Conduct, which can be found at https://numfocus.org/code-of-conduct/. The NumFOCUS Code of Conduct is available at https://numfocus.org/code-of-conduct, and while different in detailed language, shares the same core principles and in general is the same as the Code of Conduct described here.  This APE is retained for reference and use by others, but is no longer the active code of conduct for the Astropy community. For more details on the transition, see https://github.com/astropy/astropy.github.com/pull/669 and linked mailing list posts and related issues.
+As of 2026, the Astropy Community Code of Conduct is superceded by the
+NumFOCUS Code of Conduct, which can be found at 
+https://numfocus.org/code-of-conduct/. The NumFOCUS Code of Conduct is
+available at https://numfocus.org/code-of-conduct, and while different in
+detailed language, shares the same core principles and in general is the same
+as the Code of Conduct described here.  This APE is retained for reference and
+use by others, but is no longer the active code of conduct for the Astropy
+community. For more details on the transition, see 
+https://github.com/astropy/astropy.github.com/pull/669 and linked mailing list
+posts and related issues.
 
 
 Detailed description

--- a/APE8.rst
+++ b/APE8.rst
@@ -5,13 +5,13 @@ authors: Kelle Cruz, Alex Hagen, Thomas Robitaille, Erik Tollerud, Alexa Villaum
 
 date-created: 2015 May 4
 
-date-last-revised: 2015 May 17
+date-last-revised: 2025 Oct 6
 
 date-accepted: 2015 May 17
 
 type: Informational
 
-status: Accepted
+status: Superceded
 
 Abstract
 --------
@@ -26,6 +26,11 @@ text of just such a code of conduct, which will be adopted by the project to
 provide guidance to the community. The code of conduct will be licensed using
 the Creative Commons Attribution license, allowing other projects to use this
 code or adapt it to their needs.
+
+Notice of Replacement
+---------------------
+
+As of 2026, the Astropy Community Code of Conduct is superceded by the NumFOCUS Code of Conduct, which can be found at https://numfocus.org/code-of-conduct/. The NumFOCUS Code of Conduct is available at https://numfocus.org/code-of-conduct, and while different in detailed language, shares the same core principles and in general is the same as the Code of Conduct described here.  This APE is retained for reference and use by others, but is no longer the active code of conduct for the Astropy community. For more details on the transition, see https://github.com/astropy/astropy.github.com/pull/669 and linked mailing list posts and related issues.
 
 
 Detailed description

--- a/APE8.rst
+++ b/APE8.rst
@@ -30,17 +30,15 @@ code or adapt it to their needs.
 Notice of Replacement
 ---------------------
 
-As of 2026, the Astropy Community Code of Conduct is superceded by the
+As of 2026, the Astropy Community Code of Conduct is superseded by the
 NumFOCUS Code of Conduct, which can be found at 
-https://numfocus.org/code-of-conduct/. The NumFOCUS Code of Conduct is
-available at https://numfocus.org/code-of-conduct, and while different in
+https://numfocus.org/code-of-conduct/. The NumFOCUS Code of Conduct, while different in
 detailed language, shares the same core principles and in general is the same
 as the Code of Conduct described here.  This APE is retained for reference and
 use by others, but is no longer the active code of conduct for the Astropy
 community. For more details on the transition, see 
 https://github.com/astropy/astropy.github.com/pull/669 and linked mailing list
 posts and related issues.
-
 
 Detailed description
 --------------------

--- a/APE8.rst
+++ b/APE8.rst
@@ -31,6 +31,7 @@ provide guidance to the community. The code of conduct will be licensed using
 the Creative Commons Attribution license, allowing other projects to use this
 code or adapt it to their needs.
 
+
 Detailed description
 --------------------
 

--- a/APE8.rst
+++ b/APE8.rst
@@ -13,6 +13,10 @@ type: Informational
 
 status: Superseded
 
+revised-by:
+
+* Erik Tollerud - 2025 October 6 - Mark this APE as "superseded" on behalf of Astropy Coordination Committee
+
 Abstract
 --------
 
@@ -26,19 +30,6 @@ text of just such a code of conduct, which will be adopted by the project to
 provide guidance to the community. The code of conduct will be licensed using
 the Creative Commons Attribution license, allowing other projects to use this
 code or adapt it to their needs.
-
-Notice of Replacement
----------------------
-
-As of 2026, the Astropy Community Code of Conduct is superseded by the
-NumFOCUS Code of Conduct, which can be found at 
-https://numfocus.org/code-of-conduct/. The NumFOCUS Code of Conduct, while different in
-detailed language, shares the same core principles and in general is the same
-as the Code of Conduct described here.  This APE is retained for reference and
-use by others, but is no longer the active code of conduct for the Astropy
-community. For more details on the transition, see 
-https://github.com/astropy/astropy.github.com/pull/669 and linked mailing list
-posts and related issues.
 
 Detailed description
 --------------------
@@ -108,3 +99,18 @@ particular a clause was added that future changes to the code of conduct do
 not require a new APE, but do require a period of one week for anyone to
 raise objections to proposed changes. No objections were raised for this APE,
 and it was therefore accepted on May 17th 2015.
+
+As of November 2025, the Astropy Community Code of Conduct is superseded by the
+NumFOCUS Code of Conduct, which can be found at
+https://numfocus.org/code-of-conduct/. The NumFOCUS Code of Conduct, while different in
+detailed language, shares the same core principles and in general is the same
+as the Code of Conduct described here.  This APE is retained for reference and
+use by others, but is no longer the active code of conduct for the Astropy
+community. For more details on the transition, see
+https://github.com/astropy/astropy.github.com/pull/669 and linked mailing list
+posts and related issues.
+
+Previous versions of this APE
+-----------------------------
+
+* 2015-05-04 [`DOI <https://zenodo.org/records/1043913>`_] [`GitHub <https://github.com/astropy/astropy-APEs/blob/6c539bbb1d60587f253e8bf76b2529202315f0f1/APE8.rst>`_]


### PR DESCRIPTION
This closes #121 by adding a notice that APE8 is superceded by the NF Code of Conduct.

Note that this decision was made at the most recent Astropy Coordination meeting and was discussed at length in several issues and dicussion forums, so this change to the APE does not require the full APE revision process timeline (i.e., the timeline has already elapsed, and then some).