### PR TITLE
APE23: CoCo Decision

### DIFF
--- a/APE23.rst
+++ b/APE23.rst
@@ -456,9 +456,9 @@ Decision rationale
 ------------------
 
 The Coordination Committee is accepting this APE under the provisions that (1)
-the work can be completed within approximately the next year --- roughly Q1 2027
---- and (2) the authors provide clear transition documentation that will enable
-users to update their code to the new coding patterns *before* the old patterns
-are fully deprecated.  Given that much of the coding work is already complete,
-our primary concern is the follow-on effect on users.
+the work can be completed within approximately the next year --- roughly by Q2
+2027 --- and (2) the authors provide clear transition documentation that will
+enable users to update their code to the new coding patterns *before* the old
+patterns are fully deprecated.  Given that much of the coding work is already
+complete, our primary concern is the follow-on effect on users.
 

--- a/APE23.rst
+++ b/APE23.rst
@@ -5,10 +5,10 @@ Authors (alphabetical): Jeff Jennings, Adrian Price-Whelan, Nathaniel Starkman, 
 ---------------------------------------------------------------------------------------------------
 
 :date-created: 2024 11 04
-:date-last-revised: 2026 01 23
-:date-accepted: 202x xx xx
+:date-last-revised: 2026 05 27
+:date-accepted: 2026 05 27
 :type: Standard Track
-:status: Discussion
+:status: Accepted
 
 Abstract
 --------
@@ -451,3 +451,14 @@ previous section.
     sc = SkyCoord(rep, frame=frame)
     sc = SkyCoord(c)  # flexible
     sc = SkyCoord(ra_arr, dec_arr, frame=frame)  # flexible
+
+Decision rationale
+------------------
+
+The Coordination Committee is accepting this APE under the provisions that (1)
+the work can be completed within approximately the next year --- roughly Q1 2027
+--- and (2) the authors provide clear transition documentation that will enable
+users to update their code to the new coding patterns *before* the old patterns
+are fully deprecated.  Given that much of the coding work is already complete,
+our primary concern is the follow-on effect on users.
+

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ APEs
 20  `Formatting Code with Black`_                                     2022-Sep-23   Accepted   |APE 20 DOI|
 21  `Ending Long Term Support Releases`_                              2023-May-31   Accepted   |APE 21 DOI|
 22  `Astropy Affiliated Packages with pyOpenSci`_                     2024-Jan-29   Accepted   |APE 22 DOI|
-23  `Removing data storage (representations) from coordinate frames`_ 2026-Jan-23  Discussion     
+23  `Removing data storage (representations) from coordinate frames`_ 2026-May-27   Accepted   
 === ================================================================= =========== ============ ============
 
 .. _The Astropy Project Governance Charter: https://github.com/astropy/astropy-APEs/blob/main/APE0.rst


### PR DESCRIPTION
With this PR, the Astropy CoCo is formally accepting APE23 following the provided rationale:

> The Coordination Committee is accepting this APE under the provisions that (1) the work can be completed within approximately the next year --- roughly by Q2 2027 --- and (2) the authors provide clear transition documentation that will enable users to update their code to the new coding patterns *before* the old patterns are fully deprecated.  Given that much of the coding work is already complete, our primary concern is the follow-on effect on users.